### PR TITLE
Display the options text as A.I. writes it

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -1243,6 +1243,7 @@ body.connected .popupfooter, .popupfooter.always-available {
 	-o-transition: all 0.15s ease-in;
 	-webkit-transition: all 0.15s ease-in;
 	transition: all 0.15s ease-in;
+	white-space: pre-wrap;
 }
 
 .seqselitem:hover {


### PR DESCRIPTION
When using `Gens Per Action`, display the options text as A.I. writes it. White space are preserved and break lines as necessary.