### PR TITLE
Restore KoboldAI 1.17 behaviour of Retry after Back

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -3158,7 +3158,10 @@ def actionretry(data):
         if(not vars.aibusy):
             randomGameRequest(vars.recentrng, memory=vars.recentrngm)
         return
-    if actionback():
+    if(vars.recentback or actionback()):
+        vars.recentback = False
+        vars.recentedit = False
+        vars.lua_koboldbridge.feedback = None
         actionsubmit("", actionmode=vars.actionmode, force_submit=True)
         send_debug()
     elif(not vars.useprompt):


### PR DESCRIPTION
In 1.17, when you pressed Retry after pressing the Back button, it would just generate an action without deleting anything. At some point, the behaviour of Retry after Back changed back to deleting an extra action and then generating, so this restores the behaviour from 1.17.