### PR TITLE
UI changes with AI Selection in Web

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1125,9 +1125,10 @@ def load_model(use_gpu=True, gpu_layers=None, initial_load=False, online_model="
         if(vars.model == "GooseAI"):
             vars.oaiengines = "https://api.goose.ai/v1/engines"
             vars.model = "OAI"
-            args.configname = "GooseAI"
+            args.configname = "GooseAI" + "/" + online_model
+        else:
+            args.configname = vars.model + "/" + online_model
         vars.oaiurl = vars.oaiengines + "/{0}/completions".format(online_model)
-        args.configname = vars.model + "/" + online_model
     
     # If transformers model was selected & GPU available, ask to use CPU or GPU
     if(vars.model not in ["InferKit", "Colab", "OAI", "GooseAI" , "ReadOnly", "TPUMeshTransformerGPTJ", "TPUMeshTransformerGPTNeoX"]):
@@ -1926,6 +1927,9 @@ def load_model(use_gpu=True, gpu_layers=None, initial_load=False, online_model="
         set_aibusy(False)
         emit('from_server', {'cmd': 'hide_model_name'}, broadcast=True)
         time.sleep(0.1)
+        
+        if not vars.gamestarted:
+            setStartState()
 
 
 # Set up Flask routes

--- a/static/application.js
+++ b/static/application.js
@@ -2480,11 +2480,13 @@ $(document).ready(function(){
 		} else if(msg.cmd == 'selected_model_info') {
 			enableButtons([load_model_accept]);
 			$("#oaimodel").addClass("hidden")
+			$("#oaimodel")[0].options[0].selected = true;
 			if (msg.key) {
 				$("#modelkey").removeClass("hidden");
 				$("#modelkey")[0].value = msg.key_value;
 			} else {
 				$("#modelkey").addClass("hidden");
+				
 			}
 			if (msg.url) {
 				$("#modelurl").removeClass("hidden");
@@ -2513,6 +2515,10 @@ $(document).ready(function(){
 		} else if(msg.cmd == 'oai_engines') {
 			$("#oaimodel").removeClass("hidden")
 			selected_item = 0;
+			length = $("#oaimodel")[0].options.length;
+			for (let i = 0; i < length; i++) {
+				$("#oaimodel")[0].options.remove(1);
+			}
 			msg.data.forEach(function (item, index) {
 				var option = document.createElement("option");
 				option.value = item[0];

--- a/templates/index.html
+++ b/templates/index.html
@@ -289,7 +289,7 @@
 				<input class="form-control hidden" type="text" placeholder="Enter the URL of the server (For example a trycloudflare link)" id="modelurl" onchange="check_enable_model_load()">
 			</div>
 			<div class="popupfooter">
-				<select class="form-control hidden" id="oaimodel"><option value="Select OAI Model">Select OAI Model</option></select>
+				<select class="form-control hidden" id="oaimodel"><option value="">Select OAI Model</option></select>
 			</div>
 			<div class="popupfooter hidden" id=modellayers>
 				<div class='settingitem' style="width:100%">


### PR DESCRIPTION
This is a merge of my repo after updating to 1.18.

The web server now starts in read-only mode with a new UI menu for AI. In that menu the user can select a model using a menu similar to the console. It should be functional for all model types including breakmodel (uses slider bar to select chunks) and online services using a key (untested as I don't have an online service). The tqdm status bar is presented back to the web client as it loads, and the user can also find information about their model in the AI menu.

There are a few visual bugs to work out (the key field for online services shows up too frequenty and the model load status screen isn't the right kind of floating box) but given the amount of code movement required to make this work, I thought getting it in the main branch would be more important so that future merge requests will be simpler.