### PR TITLE
Add support for setting the RNG seed and full determinism

### DIFF
--- a/gensettings.py
+++ b/gensettings.py
@@ -230,6 +230,17 @@ gensettingstf = [
 	"default": 0,
   "tooltip": "Disables userscript generation modifiers."
 	},
+	{
+	"uitype": "toggle",
+	"unit": "bool",
+	"label": "Full Determinism",
+	"id": "setfulldeterminism",
+	"min": 0,
+	"max": 1,
+	"step": 1,
+	"default": 0,
+  "tooltip": "Causes generation to be fully deterministic -- the model will always output the same thing as long as your story, settings and RNG seed are the same. If this is off, only the sequence of outputs that the model makes will be deterministic."
+	},
     {
 	"uitype": "toggle",
 	"unit": "bool",

--- a/static/application.js
+++ b/static/application.js
@@ -2606,6 +2606,9 @@ $(document).ready(function(){
 		} else if(msg.cmd == "updatenogenmod") {
 			// Update toggle state
 			$("#setnogenmod").prop('checked', msg.data).change();
+		} else if(msg.cmd == "updatefulldeterminism") {
+			// Update toggle state
+			$("#setfulldeterminism").prop('checked', msg.data).change();
 		} else if(msg.cmd == "runs_remotely") {
 			remote = true;
 			hide([button_savetofile, button_import, button_importwi]);

--- a/tpu_mtj_backend.py
+++ b/tpu_mtj_backend.py
@@ -56,6 +56,22 @@ from mesh_transformer.util import to_bf16
 
 params: Dict[str, Any] = {}
 
+__seed = random.randrange(sys.maxsize)
+rng = random.Random(__seed)
+
+
+def get_rng_seed():
+    return __seed
+
+def set_rng_seed(seed: int):
+    global __seed, rng
+    rng = random.Random(seed)
+    __seed = seed
+    return seed
+
+def randomize_rng_seed():
+    return set_rng_seed(random.randrange(sys.maxsize))
+
 
 def warper_callback(logits) -> np.array:
     raise NotImplementedError("`tpu_mtj_backend.warper_callback()` needs to be defined")
@@ -728,7 +744,7 @@ class PenalizingCausalTransformer(CausalTransformer):
         assert not return_logits
         assert gen_length.ndim == 1
         assert soft_embeddings is not None
-        key = hk.PRNGSequence(random.randint(0, 2 ** 60))
+        key = hk.PRNGSequence(rng.randint(0, 2 ** 60))
         batch_size = ctx.shape[0]
         self.batch_size = batch_size
         _numseqs_aux = jnp.empty((batch_size, numseqs), dtype=np.uint32)
@@ -776,7 +792,7 @@ class PenalizingCausalTransformer(CausalTransformer):
         return sample_data, n_generated, regeneration_required, halt
     def generate_static(self, ctx, ctx_length, gen_length, numseqs, sampler_options, return_logits=False, soft_embeddings=None):
         assert not return_logits
-        key = hk.PRNGSequence(random.randint(0, 2 ** 60))
+        key = hk.PRNGSequence(rng.randint(0, 2 ** 60))
         batch_size = ctx.shape[0]
         self.batch_size = batch_size
         started_compiling_callback()


### PR DESCRIPTION
This pull request adds support for manually setting the seed for generation in the settings file, for debugging purposes. Just set the "seed" in the settings file to a 64-bit unsigned integer (or 32-bit unsigned integer on 32-bit systems).

By default, when the seed is set manually, if you retry constantly with the same model on the same settings with the same story, you will get the same *sequence* of outputs, i.e. you will get output A, then output B, then output C, and upon reloading the model you'll get the same three outputs in the same order. There is a new setting called "Full Determinism" that makes every output the same instead.