### PR TITLE
Fix base fairseq dense models when using accelerate with a GPU

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -642,6 +642,11 @@ def move_model_to_devices(model):
     import breakmodel
 
     if(utils.HAS_ACCELERATE):
+        import accelerate.utils
+        for key, value in model.state_dict().items():
+            target_dtype = torch.float32 if breakmodel.primary_device == "cpu" else torch.float16
+            if(value.dtype is not target_dtype):
+                accelerate.utils.set_module_tensor_to_device(model, key, target_dtype)
         disk_blocks = breakmodel.disk_blocks
         gpu_blocks = breakmodel.gpu_blocks
         ram_blocks = len(utils.layers_module_names) - sum(gpu_blocks)


### PR DESCRIPTION
The base models are missing one tensor that the finetuned ones have (the finetuned ones were saved by transformers but the base models weren't). Transformers is able to generate this specific tensor automatically since it is a tensor that is the same for every XGLM model with the same `d_model`, but it always generates it as 32-bit which is a problem because on GPU we need everything to be 16-bit. This isn't a problem on Official because we can just call model.half(), but we can't do that here because it will throw an error if we're using accelerate's disk cache. This adds an alternative method to convert transformers' automatically generated tensors to 16-bit or 32-bit based on whether we are running on CPU or GPU.