### PR TITLE
Added functionality to load all of the CLI arguments via a single JSON file

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1044,6 +1044,7 @@ def general_startup(override_args=None):
     parser.add_argument("--no_aria2", action='store_true', default=False, help="Prevents KoboldAI from using aria2 to download huggingface models more efficiently, in case aria2 is causing you issues")
     parser.add_argument("--lowmem", action='store_true', help="Extra Low Memory loading for the GPU, slower but memory does not peak to twice the usage")
     parser.add_argument("--savemodel", action='store_true', help="Saves the model to the models folder even if --colab is used (Allows you to save models to Google Drive)")
+    parser.add_argument("--customsettings", help="Preloads arguements from json file. You only need to provide the location of the json file. Use customsettings.json template file. It can be renamed if you wish so that you can store multiple configurations. Leave any settings you want as default as null. Any values you wish to set need to be in double quotation marks")
     #args: argparse.Namespace = None
     if "pytest" in sys.modules and override_args is None:
         args = parser.parse_args([])
@@ -1056,6 +1057,14 @@ def general_startup(override_args=None):
         args = parser.parse_args(shlex.split(os.environ["KOBOLDAI_ARGS"]))
     else:
         args = parser.parse_args()
+
+    if args.customsettings:
+        f = open (args.customsettings)
+        importedsettings = json.load(f)
+        for items in importedsettings:
+            if importedsettings[items] is not None:
+                setattr(args, items, importedsettings[items])            
+        f.close()
 
     vars.model = args.model;
     vars.revision = args.revision

--- a/customsettings_template.json
+++ b/customsettings_template.json
@@ -1,3 +1,1 @@
 {"aria2_port":null, "breakmodel":null, "breakmodel_disklayers":null, "breakmodel_gpulayers":null, "breakmodel_layers":null, "colab":null, "configname":null, "cpu":null, "host":null, "localtunnel":null, "lowmem":null, "model":null, "ngrok":null, "no_aria2":null, "noaimenu":null, "nobreakmodel":null, "override_delete":null, "override_rename":null, "path":null, "port":null, "quiet":null, "remote":null, "revision":null, "savemodel":null, "unblock":null}
-
-

--- a/customsettings_template.json
+++ b/customsettings_template.json
@@ -1,0 +1,3 @@
+{"aria2_port":null, "breakmodel":null, "breakmodel_disklayers":null, "breakmodel_gpulayers":null, "breakmodel_layers":null, "colab":null, "configname":null, "cpu":null, "host":null, "localtunnel":null, "lowmem":null, "model":null, "ngrok":null, "no_aria2":null, "noaimenu":null, "nobreakmodel":null, "override_delete":null, "override_rename":null, "path":null, "port":null, "quiet":null, "remote":null, "revision":null, "savemodel":null, "unblock":null}
+
+


### PR DESCRIPTION
I have added the functionality to load all of the CLI arguments via a single JSON file

The template JSON file lists all the base arguments with the attribute null. Any values you wish to pass in via the JSON you just need to change from null to the double quoted value. It will skip any values that are left as null. So people don't need to worry about removing the ones they don't need or trying to find the name for the one they need. They can just change what they need and ignore the rest.

I was able to fully test this with the model, breakmodel_gpulayers, breakmodel_disklayers, port without any issues. I don't see why the other ones wouldn't work and the other values do seem to update. I just don't know enough about what the other arguments do to test them fully. I have added them as a result, but wanted to note it as those specific ones may require additional testing.

This was tested on Linux.