### PR TITLE
Fix arbitrary newline insertion when token streaming is enabled

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -2351,7 +2351,12 @@ $(document).ready(function(){
 			var element = game_text.children('#n' + index);
 			if(element.length) {
 				unbindGametext();
-				if((element[0].nextSibling === null || element[0].nextSibling.nodeType !== 1 || element[0].nextSibling.tagName !== "CHUNK") && element[0].previousSibling !== null && element[0].previousSibling.tagName === "CHUNK") {
+				if(
+					(element[0].nextSibling === null || element[0].nextSibling.nodeType !== 1 || element[0].nextSibling.tagName !== "CHUNK")
+					&& element[0].previousSibling !== null
+					&& element[0].previousSibling.tagName === "CHUNK"
+					&& !$("#setoutputstreaming")[0].checked
+				) {
 					element[0].previousSibling.appendChild(document.createElement("br"));
 				}
 				element.remove();  // Remove the chunk


### PR DESCRIPTION
In adventure mode with token streaming enabled, retrying after an action would cause a `<br>` element to be inserted into the action. This prevents the insertion of the `<br>` if token streaming is enabled.