### PR TITLE
Add editor shortcuts and actually fix streaming newline bug

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -3275,6 +3275,32 @@ $(document).ready(function(){
 			return true;
 		}
 	});
+
+	// Shortcuts
+	$(window).keydown(function (ev) {
+		// Only ctrl prefixed (for now)
+		if (!ev.ctrlKey) return;
+
+		let handled = true;
+		switch (ev.key) {
+			// Ctrl+Z - Back
+			case "z":
+				button_actback.click();
+				break;
+			// Ctrl+Y - Forward
+			case "y":
+				button_actfwd.click();
+				break;
+			// Ctrl+E - Retry
+			case "e":
+				button_actretry.click();
+				break;
+			default:
+				handled = false;
+		}
+
+		if (handled) ev.preventDefault();
+	});
 });
 
 

--- a/static/application.js
+++ b/static/application.js
@@ -2335,7 +2335,11 @@ $(document).ready(function(){
 			} else if (!empty_chunks.has(index.toString())) {
 				// Append at the end
 				unbindGametext();
-				var lc = game_text[0].lastChild;
+
+				// game_text can contain things other than chunks (stream
+				// preview), so we use querySelector to get the last chunk.
+				var lc = game_text[0].querySelector("chunk:last-of-type");
+
 				if(lc.tagName === "CHUNK" && lc.lastChild !== null && lc.lastChild.tagName === "BR") {
 					lc.removeChild(lc.lastChild);
 				}
@@ -2355,7 +2359,6 @@ $(document).ready(function(){
 					(element[0].nextSibling === null || element[0].nextSibling.nodeType !== 1 || element[0].nextSibling.tagName !== "CHUNK")
 					&& element[0].previousSibling !== null
 					&& element[0].previousSibling.tagName === "CHUNK"
-					&& !$("#setoutputstreaming")[0].checked
 				) {
 					element[0].previousSibling.appendChild(document.createElement("br"));
 				}


### PR DESCRIPTION
This pull request adds editor shortcuts and fixes the streaming newline bug (again). The shortcuts are as follows: Ctrl+Z to undo, Ctrl+Y to redo, and Ctrl+E to retry. As for the bug, the real fix was to detect the last chunk instead of the last child of `game_text` when adding newlines. The previous fix added another bug which deleted a newline when redoing while streaming was enabled (oops). I have tested the shortcuts on Firefox 103 on Linux, and from my research there should be no conflicts.