### PR TITLE
Add token probability visualizer

### DIFF
--- a/gensettings.py
+++ b/gensettings.py
@@ -263,6 +263,17 @@ gensettingstf = [
 	"default": 0,
   "tooltip": "Shows outputs to you as they are made. Does not work with more than one gens per action."
 	},
+    {
+	"uitype": "toggle",
+	"unit": "bool",
+	"label": "Show Token Probabilities",
+	"id": "setshowprobs",
+	"min": 0,
+	"max": 1,
+	"step": 1,
+	"default": 0,
+  "tooltip": "Shows token selection probabilities. Does not work with more than one gens per action."
+	},
 ]
 
 gensettingsik =[{

--- a/static/application.js
+++ b/static/application.js
@@ -79,6 +79,7 @@ var rs_close;
 var seqselmenu;
 var seqselcontents;
 var stream_preview;
+var token_prob_container;
 
 var storyname = null;
 var memorymode = false;
@@ -890,7 +891,7 @@ function formatChunkInnerText(chunk) {
 }
 
 function dosubmit(disallow_abort) {
-	ignore_stream = false;
+	beginStream();
 	submit_start = Date.now();
 	var txt = input_text.val().replace(/\u00a0/g, " ");
 	if((disallow_abort || gamestate !== "wait") && !memorymode && !gamestarted && ((!adventure || !action_mode) && txt.trim().length == 0)) {
@@ -905,7 +906,7 @@ function dosubmit(disallow_abort) {
 }
 
 function _dosubmit() {
-	ignore_stream = false;
+	beginStream();
 	var txt = submit_throttle.txt;
 	var disallow_abort = submit_throttle.disallow_abort;
 	submit_throttle = null;
@@ -2086,6 +2087,11 @@ function unbindGametext() {
 	gametext_bound = false;
 }
 
+function beginStream() {
+	ignore_stream = false;
+	token_prob_container[0].innerHTML = "";
+}
+
 function endStream() {
 	// Clear stream, the real text is about to be displayed.
 	ignore_stream = true;
@@ -2121,6 +2127,14 @@ function RemoveAllButFirstOption(selectElement) {
    for(i = L; i >= 1; i--) {
       selectElement.remove(i);
    }
+}
+
+function interpolateRGB(color0, color1, t) {
+	return [
+		color0[0] + ((color1[0] - color0[0]) * t),
+		color0[1] + ((color1[1] - color0[1]) * t),
+		color0[2] + ((color1[2] - color0[2]) * t),
+	]
 }
 
 //=================================================================//
@@ -2214,6 +2228,8 @@ $(document).ready(function(){
 	rs_close          = $("#btn_rsclose");
 	seqselmenu        = $("#seqselmenu");
 	seqselcontents    = $("#seqselcontents");
+	token_prob_container = $("#token_prob_container");
+	token_prob_menu = $("#token_prob_menu");
 
 	// Connect to SocketIO server
 	socket = io.connect(window.document.origin, {transports: ['polling', 'websocket'], closeOnBeforeunload: false});
@@ -2277,14 +2293,68 @@ $(document).ready(function(){
 			// appearing after the output. To combat this, we only allow tokens
 			// to be displayed after requesting and before recieving text.
 			if (ignore_stream) return;
-			if (!$("#setoutputstreaming")[0].checked) return;
 
-			if (!stream_preview) {
+			let streamingEnabled = $("#setoutputstreaming")[0].checked;
+			let probabilitiesEnabled = $("#setshowprobs")[0].checked;
+
+			if (!streamingEnabled && !probabilitiesEnabled) return;
+
+			if (!stream_preview && streamingEnabled) {
 				stream_preview = document.createElement("span");
 				game_text.append(stream_preview);
 			}
 
-			stream_preview.innerText += msg.data.join("");
+			for (const token of msg.data) {
+				if (streamingEnabled) stream_preview.innerText += token.decoded;
+
+				if (probabilitiesEnabled) {
+					// Probability display
+					let probDiv = document.createElement("div");
+					probDiv.classList.add("token-probs");
+
+					let probTokenSpan = document.createElement("span");
+					probTokenSpan.classList.add("token-probs-header");
+					probTokenSpan.innerText = token.decoded.replaceAll("\n", "\\n");
+					probDiv.appendChild(probTokenSpan);
+
+					let probTable = document.createElement("table");
+					let probTBody = document.createElement("tbody");
+					probTable.appendChild(probTBody);
+
+					for (const probToken of token.probabilities) {
+						let tr = document.createElement("tr");
+						let rgb = interpolateRGB(
+							[255, 255, 255],
+							[0, 255, 0],
+							probToken.score
+						).map(Math.round);
+						let color = `rgb(${rgb.join(", ")})`;
+
+						if (probToken.decoded === token.decoded) {
+							tr.classList.add("token-probs-final-token");
+						}
+
+						let tds = {};
+
+						for (const property of ["tokenId", "decoded", "score"]) {
+							let td = document.createElement("td");
+							td.style.color = color;
+							tds[property] = td;
+							tr.appendChild(td);
+						}
+
+						tds.tokenId.innerText = probToken.tokenId;
+						tds.decoded.innerText = probToken.decoded.toString().replaceAll("\n", "\\n");
+						tds.score.innerText = (probToken.score * 100).toFixed(2) + "%";
+
+						probTBody.appendChild(tr);
+					}
+
+					probDiv.appendChild(probTable);
+					token_prob_container.append(probDiv);
+				}
+			}
+
 			scrollToBottom();
 		} else if(msg.cmd == "updatescreen") {
 			var _gamestarted = gamestarted;
@@ -2559,6 +2629,14 @@ $(document).ready(function(){
 		} else if(msg.cmd == "updateoutputstreaming") {
 			// Update toggle state
 			$("#setoutputstreaming").prop('checked', msg.data).change();
+		} else if(msg.cmd == "updateshowprobs") {
+			$("#setshowprobs").prop('checked', msg.data).change();
+
+			if(msg.data) {
+				token_prob_menu.removeClass("hidden");
+			} else {
+				token_prob_menu.addClass("hidden");
+			}
 		} else if(msg.cmd == "allowtoggle") {
 			// Allow toggle change states to propagate
 			allowtoggle = msg.data;
@@ -2954,7 +3032,7 @@ $(document).ready(function(){
 	});
 	
 	button_actretry.on("click", function(ev) {
-		ignore_stream = false;
+		beginStream();
 		hideMessage();
 		socket.send({'cmd': 'retry', 'chatname': chatmode ? chat_name.val() : undefined, 'data': ''});
 		hidegenseqs();
@@ -3201,7 +3279,7 @@ $(document).ready(function(){
 	});
 	
 	rs_accept.on("click", function(ev) {
-		ignore_stream = false;
+		beginStream();
 		hideMessage();
 		socket.send({'cmd': 'rndgame', 'memory': $("#rngmemory").val(), 'data': topic.val()});
 		hideRandomStoryPopup();

--- a/static/custom.css
+++ b/static/custom.css
@@ -1648,3 +1648,50 @@ body.connected .popupfooter, .popupfooter.always-available {
 	cursor: pointer;
 	background-color: #688f1f;
 }
+
+#token_prob_menu {
+	color: white;
+	background-color: #262626;
+}
+
+.token-probs {
+	display: inline-block;
+	text-align: center;
+	margin-right: 5px;
+}
+
+.token-probs > table {
+	width: 100%;
+}
+
+.token-probs > table > tbody > tr > td {
+	border: 1px solid #262626;
+	border-collapse: collapse;
+	padding: 2px 15px;
+}
+
+.token-probs > table > tbody > tr {
+	background-color: #3e3e3e;
+}
+
+.token-probs > table > tbody > tr:nth-child(2n) {
+	background-color: #575757;
+}
+
+.token-probs-final-token {
+	font-weight: bold;
+	text-decoration: underline;
+}
+
+.token-probs-final-token > td {
+	background: #5c8a5a;
+}
+
+.token-probs-header {
+	display: block;
+}
+
+#token_prob_container {
+	overflow-x: scroll;
+	white-space: nowrap;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -123,6 +123,11 @@
 		</div>
 		<div class="row" id="formatmenu">
 		</div>
+
+		<div id="token_prob_menu" class="row hidden">
+			<div id="token_prob_container"></div>
+		</div>
+
 		<div class="layer-container">
 			<div class="layer-bottom row" id="gamescreen">
 				<span id="gametext" contenteditable="true"><p>...</p></span>


### PR DESCRIPTION
This PR adds a setting that enables the display of token probabilities directly in the UI during generation. It works by adding a `LogitsProcessor` that takes the softmax of the token scores and lets the token streaming queue send them to the client. Due to how similar this feature and token streaming are, they share the same queue. This means tokens and their probabilities will be streamed to the client if either the token streaming *or* token probabilities options are enabled. This shared packet does not affect the UI, and the two features are independent of each other from the user's perspective.

The UI for the visualizer is shown here, tested with a teeny tiny model.
![image](https://user-images.githubusercontent.com/69319754/182930547-e04a743b-5c7e-40b8-b77b-8ef4ff8ebdd9.png)