### PR TITLE
Fix error that occurs when using dynamic TPU backend

### DIFF
--- a/tpu_mtj_backend.py
+++ b/tpu_mtj_backend.py
@@ -533,7 +533,7 @@ def sample_func(data, key, numseqs_aux, badwords, repetition_penalty, generated_
                 gen_length,
                 rpslope,
                 rprange,
-            )
+            ),
             **sampler_options,
         )
         # Remember what token was picked


### PR DESCRIPTION
Fixes this error:
```
Traceback (most recent call last):
  File "aiserver.py", line 5057, in tpumtjgenerate
    excluded_world_info=found_entries,
  File "/usr/local/lib/python3.7/dist-packages/eventlet/tpool.py", line 132, in execute
    six.reraise(c, e, tb)
  File "/usr/local/lib/python3.7/dist-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.7/dist-packages/eventlet/tpool.py", line 86, in tworker
    rv = meth(*args, **kwargs)
  File "/content/KoboldAI-Client/tpu_mtj_backend.py", line 835, in infer_dynamic
    use_callback=use_callback,
  File "/content/KoboldAI-Client/tpu_mtj_backend.py", line 775, in generate_dynamic
    sample_data, sample_key = sample_func(sample_data, sample_key, _numseqs_aux, badwords, repetition_penalty, params["seq"] + n_generated, gen_length, rpslope, rprange, sampler_options)
  File "/content/KoboldAI-Client/tpu_mtj_backend.py", line 554, in sample_func
    carry = sample_loop_fn(carry)
  File "/content/KoboldAI-Client/tpu_mtj_backend.py", line 537, in sample_loop_fn
    **sampler_options,
TypeError: unsupported operand type(s) for ** or pow(): 'tuple' and 'dict'
```