### PR TITLE
Disable load model button on colab/when told to in CLI args

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -7981,7 +7981,12 @@ def new_ui_index():
     if 'story' in session:
         if session['story'] not in koboldai_vars.story_list():
             session['story'] = 'default'
-    return render_template('index_new.html', settings=gensettings.gensettingstf, on_colab=koboldai_vars.on_colab )
+    return render_template(
+        'index_new.html',
+        settings=gensettings.gensettingstf,
+        on_colab=koboldai_vars.on_colab,
+        hide_ai_menu=args.noaimenu
+    )
 
 @logger.catch
 def ui2_connect():

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -38,10 +38,12 @@
 					<b class="noselect">1) Model: </b>
 			</div>
 			<div style="display: flex; justify-content: center;">
-				<button class="settings_button" onclick="socket.emit('load_model_button', {});">
-					<span class="material-icons-outlined cursor" tooltip="Load Model" style="font-size: 1.4em;">folder_open</span>
-					<span class="button_label">Load Model</span>
-				</button>
+				{% if not hide_ai_menu %}
+					<button class="settings_button" onclick="socket.emit('load_model_button', {});">
+						<span class="material-icons-outlined cursor" tooltip="Load Model" style="font-size: 1.4em;">folder_open</span>
+						<span class="button_label">Load Model</span>
+					</button>
+				{% endif %}
 				<select class="var_sync_model_selected_preset settings_select presets" onchange='sync_to_server(this)'><option>Preset</option></select>
 			</div>
 			{% if not on_colab %}


### PR DESCRIPTION
Currently switching models makes the TPU cry and we do not want to upset our dearest hardware friend.

In the future it'd probably be best to teach the TPU how to not be afraid of switching models, provided we have some limitations that prevent loading itty bitty or way too big models on the TPU.