### PR TITLE
Fix image retry

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -9629,6 +9629,12 @@ def log_image_generation(
     with open(db_path, "w") as file:
         json.dump(j, file, indent="\t")
 
+@socketio.on("retry_generated_image")
+@logger.catch
+def UI2_retry_generated_image():
+    eventlet.sleep(0)
+    generate_story_image(koboldai_vars.picture_prompt)
+
 def generate_story_image(
     prompt: str,
     file_prefix: str = "image",
@@ -9678,9 +9684,6 @@ def generate_story_image(
     b64_data = base64.b64encode(buffer.getvalue()).decode("ascii")
 
     koboldai_vars.picture = b64_data
-    
-    
-
 
 def generate_image(prompt: str) -> Optional[Image.Image]:
     if koboldai_vars.img_gen_priority == 4:

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -6672,7 +6672,7 @@ function imgGenRetry() {
 	const image = $el(".action_image");
 	if (!image) return;
 	$el("#image-loading").classList.remove("hidden");
-	socket.emit("generate_image", {'action_id': image.getAttribute("chunk")});
+	socket.emit("retry_generated_image");
 }
 
 /* Genres */


### PR DESCRIPTION
Previously the image retry wouldn't work on custom prompts due to a merge error removing `retry_generated_image`