### PR TITLE
Fixed welcome screen content overflow on mobile devices.

### DIFF
--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -1658,7 +1658,7 @@ body {
 
 .themerow {
 	grid-area: theme;
-	width: 500px;
+	/* width: 500px; */
 	margin-left: 10px;
 }
 


### PR DESCRIPTION
I think a hardcoded 500px width for one of the divs was breaking the layout on mobile.
Removing it seems to do the trick. Please review in case I accidentally broke something.

- Concedo