### PR TITLE
Adding CORS support to allow cross origin requests.

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -563,12 +563,14 @@ from flask_socketio import SocketIO, emit, join_room, leave_room
 from flask_socketio import emit as _emit
 from flask_session import Session
 from flask_compress import Compress
+from flask_cors import CORS
 from werkzeug.exceptions import HTTPException, NotFound, InternalServerError
 import secrets
 app = Flask(__name__, root_path=os.getcwd())
 app.secret_key = secrets.token_hex()
 app.config['SESSION_TYPE'] = 'filesystem'
 app.config['TEMPLATES_AUTO_RELOAD'] = True
+CORS(app)
 Compress(app)
 socketio = SocketIO(app, async_method="eventlet", manage_session=False, cors_allowed_origins='*', max_http_buffer_size=10_000_000)
 #socketio = SocketIO(app, async_method="eventlet", manage_session=False, cors_allowed_origins='*', max_http_buffer_size=10_000_000, logger=logger, engineio_logger=True)

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -27,6 +27,7 @@ dependencies:
   - pip:
     - flask-cloudflared
     - flask-ngrok
+    - flask-cors
     - lupa==1.10
     - transformers==4.25.1
     - huggingface_hub>=0.10.1

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -26,6 +26,7 @@ dependencies:
     - torch==1.12.1+rocm5.1.1
     - flask-cloudflared
     - flask-ngrok
+    - flask-cors
     - lupa==1.10
     - transformers==4.25.1
     - huggingface_hub>=0.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests
 torch >= 1.9, < 1.13
 flask-cloudflared
 flask-ngrok
+flask-cors
 eventlet
 dnspython==2.2.1
 lupa==1.10

--- a/requirements_mtj.txt
+++ b/requirements_mtj.txt
@@ -13,6 +13,7 @@ flask
 Flask-SocketIO
 flask-cloudflared >= 0.0.5
 flask-ngrok
+flask-cors
 eventlet
 dnspython==2.2.1
 lupa==1.10


### PR DESCRIPTION
Adding CORS support to allow cross origin requests. 
This will allow browser based clients to interface with local installations of kobold. Python scripts (e.g. the existing horde bridge) are not affected by CORS and are already able to do so.

Also added new dependency for the required `flask-cors` package