### PR TITLE
Fix boolean API schemas name clash

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -10581,7 +10581,7 @@ class StoryChunkSchema(StoryNumsChunkSchema, KoboldSchema):
 class StorySchema(KoboldSchema):
     results: List[StoryChunkSchema] = fields.List(fields.Nested(StoryChunkSchema), required=True, metadata={"description": "Array of story actions. The array is sorted such that actions closer to the end of this array are closer to the end of the story."})
 
-class BasicBooleanSchema(KoboldSchema):
+class BasicBooleanResultSchema(KoboldSchema):
     result: bool = fields.Boolean(required=True)
 
 class StoryNumsSchema(KoboldSchema):
@@ -11269,7 +11269,7 @@ def get_story_nums_num(num: int):
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
     """
     if num == 0:
         return {"result": koboldai_vars.gamestarted}
@@ -11667,7 +11667,7 @@ def get_world_info_uids_uid(uid: int):
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
     """
     return {"result": uid in koboldai_vars.worldinfo_u and koboldai_vars.worldinfo_u[uid]["init"]}
 
@@ -11800,7 +11800,7 @@ def get_world_info_folders_none_uids_uid(uid: int):
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
     """
     return {"result": uid in koboldai_vars.worldinfo_u and koboldai_vars.worldinfo_u[uid]["folder"] is None and koboldai_vars.worldinfo_u[uid]["init"]}
 
@@ -11937,7 +11937,7 @@ def get_world_info_folders_folder_uid_uids_entry_uid(folder_uid: int, entry_uid:
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
     """
     return {"result": entry_uid in koboldai_vars.worldinfo_u and koboldai_vars.worldinfo_u[entry_uid]["folder"] == folder_uid and koboldai_vars.worldinfo_u[entry_uid]["init"]}
 
@@ -12466,7 +12466,7 @@ def get_world_info_uid_selective(uid: int):
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
         404:
           description: Not found
           content:
@@ -12558,7 +12558,7 @@ def get_world_info_uid_constant(uid: int):
           description: Successful request
           content:
             application/json:
-              schema: BasicBooleanSchema
+              schema: BasicBooleanResultSchema
         404:
           description: Not found
           content:


### PR DESCRIPTION
## Preamble
It wasn't possible to set boolean fields via v1 API requests because of two schemas with the same name BasicBooleanSchema (one for `value`, one for `result`). I renamed the output schema to BasicBooleanResultSchema, thus resolving the clash.

The affected endpoints were:
* PUT api/v1/world_info/{uid}/selective
* PUT api/v1/world_info/{uid}/constant

I will also appreciate if this could be backported to the stable branch (I can PR there if you wish).

## Before
![image](https://user-images.githubusercontent.com/18619528/218259071-9adc62f3-300e-44ca-b1b9-566873c3081a.png)

## After
(as an input)
![image](https://user-images.githubusercontent.com/18619528/218258966-2f9d2098-3738-4426-a881-258c8e1300a6.png)
(as an output)
![image](https://user-images.githubusercontent.com/18619528/218259127-dd309d19-3a92-450c-be00-35e59da3274c.png)
