### PR TITLE
Don't hide genseqs on submit memory

### DIFF
--- a/static/application.js
+++ b/static/application.js
@@ -946,7 +946,9 @@ function _dosubmit() {
 	submit_throttle = null;
 	input_text.val("");
 	hideMessage();
-	hidegenseqs();
+	if(!memorymode){
+		hidegenseqs();
+	}
 	socket.send({'cmd': 'submit', 'allowabort': !disallow_abort, 'actionmode': adventure ? action_mode : 0, 'chatname': chatmode ? chat_name.val() : undefined, 'data': txt});
 }
 


### PR DESCRIPTION
Reproduction:
- Set it to give multiple Gens Per Action;
- Click Submit and wait;
- Click Memory;
- Click Submit.
Result: You will lose the output. The same doesn't happen when you do it with WI.
Expected: Keep the output visible.

This simple PR fix this issue.