### PR TITLE
updates PyTorch to allow AMD gpu splitting

### DIFF
--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -22,8 +22,8 @@ dependencies:
   - Pillow
   - psutil
   - pip:
-    - --extra-index-url https://download.pytorch.org/whl/rocm5.1.1
-    - torch==1.12.1+rocm5.1.1
+    - --extra-index-url https://download.pytorch.org/whl/rocm5.2
+    - torch==1.13.1+rocm5.2
     - flask-cloudflared==0.0.10
     - flask-ngrok
     - flask-cors


### PR DESCRIPTION
Feature adding update for AMD GPUs:
PyTorch version from _1.12.1+rocm5.1.1_ does not work when splitting models across multiple AMD GPUs 
The version is changed to the new stable version _1.13.1+rocm5.2_ to allow AMD GPUs to utilize VRAM splitting across multiple GPUs.


Behavior on 1.12.1+rocm5.1.1 when generating on multiple AMD GPU's:
Either nonsense or errors:

>  his the ( A " � " the likely ( a ( " Barnes the re the she he gold we one ( most all the " he I ( his inc that they corporate an we the " � F they � more money F just she negative G
>  even the com the emerging S R company ( ( – re you order ( call hold ( ( negative the fill a ( (
or

> runtime: probability tensor contains either inf, nan or element < 0

Behavior on updated PyTorch 1.13.1+rocm5.2:
Working correctly