### PR TITLE
Removed chatmode blank newlines & Chat mode auto stops at newline

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -320,6 +320,7 @@ model_menu = {
         ["GooseAI API (requires API key)", "GooseAI", "None", False],
         ["OpenAI API (requires API key)", "OAI", "None", False],
         ["InferKit API (requires API key)", "InferKit", "None", False],
+        
         ["KoboldAI API", "API", "None", False],
         ["Basic Model API", "Colab", "", False],
         ["KoboldAI Horde", "CLUSTER", "None", False],
@@ -6498,7 +6499,8 @@ def applyoutputformatting(txt, no_sentence_trimming=False, no_single_line=False)
         txt = utils.singlelineprocessing(txt, koboldai_vars)
  	# Chat Mode Trimming
     if(koboldai_vars.chatmode):
-        txt = utils.chatmodeprocessing(txt, koboldai_vars)   
+        txt = utils.chatmodeprocessing(txt, koboldai_vars) 
+        txt = utils.singlelineprocessing(txt, koboldai_vars)   
     for sub in koboldai_vars.substitutions:
         if not sub["enabled"]:
             continue

--- a/aiserver.py
+++ b/aiserver.py
@@ -4851,7 +4851,7 @@ def actionsubmit(data, actionmode=0, force_submit=False, force_prompt_gen=False,
                 botname = ""
             data = re.sub(r'\n+', ' ', data)
             if(len(data)):
-                data = f"\n{koboldai_vars.chatname}: {data}\n{botname}"
+                data = f"{koboldai_vars.chatname}: {data}\n{botname}"
         
         # If we're not continuing, store a copy of the raw input
         if(data != ""):
@@ -9488,7 +9488,7 @@ def UI_2_generate_wi(data):
     prompt = f"{yes_str}\n\n{extractor_string}"
     
     # logger.info(prompt)
-    # TODO: Make single_line mode that stops on newline rather than bans it (for title)
+    # TODO: Make single_line mode that stops on newline rather than bans it (for title) --> Update: created as SingleLineStopper(StoppingCriteria)
     out_text = tpool.execute(
         raw_generate,
         prompt,

--- a/gensettings.py
+++ b/gensettings.py
@@ -825,7 +825,7 @@ gensettingstf = [
 	"max": 1,
 	"step": 1,
 	"default": 0,
-    "tooltip": "If enabled a specfic seed will be used for the random generator on text generation",
+    "tooltip": "If enabled, a specific seed will be used for the random generator on text generation",
     "menu_path": "Settings",
     "sub_path": "Other",
     "classname": "system",

--- a/utils.py
+++ b/utils.py
@@ -150,6 +150,8 @@ def singlelineprocessing(txt, koboldai_vars):
 def chatmodeprocessing(txt, koboldai_vars):
     chatregex = re.compile(r'%s:[.|\n|\W|\w]*'%koboldai_vars.chatname)
     txt = chatregex.sub('', txt)
+    txt = koboldai_vars.regex_sl.sub('', txt)
+
     if(len(koboldai_vars.actions) > 0):
         if(len(koboldai_vars.actions[-1]) > 0):
             action = koboldai_vars.actions[-1]
@@ -161,8 +163,8 @@ def chatmodeprocessing(txt, koboldai_vars):
     else:
         action = koboldai_vars.prompt
         lastchar = action[-1] if len(action) else ""
-#    if(lastchar != "\n"):
-#        txt = txt + "\n"
+#	if(lastchar != "\n"):	
+#        txt = txt + "\n"	
     return txt
 
 #==================================================================#

--- a/utils.py
+++ b/utils.py
@@ -161,8 +161,8 @@ def chatmodeprocessing(txt, koboldai_vars):
     else:
         action = koboldai_vars.prompt
         lastchar = action[-1] if len(action) else ""
-    if(lastchar != "\n"):
-        txt = txt + "\n"
+#    if(lastchar != "\n"):
+#        txt = txt + "\n"
     return txt
 
 #==================================================================#


### PR DESCRIPTION
When in Chatmode, the responses would be given with 1 (or sometimes 2) blank lines in between them each time like this:
```
User A: [text]
User B: [text]

User A: [text]
User B: [text]

User A: [text]
User B: [text]
```

I removed the extra newline and made the chatmode formatting more like a normal chat room where its like this:

```
User A: [text]
User B: [text]
User A: [text]
User B: [text]
User A: [text]
User B: [text]
```

then I made it so turning on chatmode automatically stops at the newline through the singlelinestopper


Included is also a typo fix in the generation settings file