### PR TITLE
Do not subtract actions

### DIFF
--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1801,7 +1801,6 @@ class KoboldStoryRegister(object):
             if "wi_highlighted_text" in self.actions[action_id]:
                 del self.actions[action_id]["wi_highlighted_text"]
             self.actions[action_id]['Selected Text Length'] = 0
-            self.action_count -= 1
             process_variable_changes(self._socketio, "story", 'actions', {"id": action_id, 'action':  self.actions[action_id]}, None)
             self.set_game_saved()
             logger.debug("Calcing AI Text from Action Delete")


### PR DESCRIPTION
If you edit and delete an entire action, a delete action will be called, but the actions will never be deleted.
This can lead to actions being out of sync and cause loss of data.
I believe the method wants to keep the action for history purposes but with an empty text.
This PR corrects the actions desync.