### PR TITLE
added local rng_states variable and fixed minor typo

### DIFF
--- a/gensettings.py
+++ b/gensettings.py
@@ -825,7 +825,7 @@ gensettingstf = [
 	"max": 1,
 	"step": 1,
 	"default": 0,
-    "tooltip": "If enabled a specfic seed will be used for the random generator on text generation",
+    "tooltip": "If enabled, a specific seed will be used for the random generator on text generation",
     "menu_path": "Settings",
     "sub_path": "Other",
     "classname": "system",

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1202,12 +1202,12 @@ class system_settings(settings):
     local_only_variables = ['lua_state', 'lua_logname', 'lua_koboldbridge', 'lua_kobold', 
                             'lua_koboldcore', 'regex_sl', 'acregex_ai', 'acregex_ui', 'comregex_ai', 
                             'comregex_ui', 'sp', '_horde_pid', 'inference_config', 'image_pipeline', 
-                            'summarizer', 'summary_tokenizer', 'tts_model']
+                            'summarizer', 'summary_tokenizer', 'tts_model', 'rng_states']
     no_save_variables = ['lua_state', 'lua_logname', 'lua_koboldbridge', 'lua_kobold', 
                          'lua_koboldcore', 'sp', 'sp_length', '_horde_pid', 'horde_share', 'aibusy', 
                          'serverstarted', 'inference_config', 'image_pipeline', 'summarizer', 
                          'summary_tokenizer', 'use_colab_tpu', 'noai', 'disable_set_aibusy', 'cloudflare_link', 'tts_model',
-                         'generating_image', 'bit_8_available', 'host', 'hascuda', 'usegpu']
+                         'generating_image', 'bit_8_available', 'host', 'hascuda', 'usegpu', 'rng_states']
     settings_name = "system"
     def __init__(self, socketio, koboldai_var):
         self._socketio = socketio
@@ -1263,6 +1263,7 @@ class system_settings(settings):
         self.disable_output_formatting = False
         self.full_determinism = False  # Whether or not full determinism is enabled
         self.seed_specified = False  # Whether or not the current RNG seed was specified by the user (in their settings file)
+        self.rng_states = {} # creates an empty dictionary to store the random number generator (RNG) states for a given seed, which is used to restore the RNG state later on
         self.seed        = None   # The current RNG seed (as an int), or None if unknown
         self.alt_gen = False # Use the calc_ai_text method for generating text to go to the AI
         self.theme_list = [".".join(f.split(".")[:-1]) for f in os.listdir("./themes") if os.path.isfile(os.path.join("./themes", f))]


### PR DESCRIPTION
<div align="center">
  <div style="background-color: #F9F9F9; padding: 20px; border: 1px solid #DADADA; border-radius: 5px; box-shadow: 2px 2px 5px #DADADA; max-width: 600px;">
    <h2 style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 28px; margin-bottom: 10px;">Fixing the sampler_seed parameter bug</h2>
    <p style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 18px; line-height: 1.5; margin-bottom: 20px;">When passing the <code>sampler_seed</code> parameter through the API after starting up a model, it would return <code>AttributeError: 'undefined_settings' object has no attribute 'rng_states'</code>. This was due to a missing variable, which resulted in the error when trying to set the seed via the API.</p>
    <p style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 18px; line-height: 1.5; margin-bottom: 20px;">I have fixed this bug by adding the missing <code>rng_states</code> variable. This will now allow users to set the seed via the API without encountering any errors. I have also cleaned up the commits to make it easier to understand.</p>
    <div style="text-align: center;">
      <a href="https://github.com/henk717/KoboldAI/pull/304/files" style="background-color: #0080FF; color: #FFFFFF; padding: 10px 20px; border-radius: 5px; text-decoration: none; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; font-size: 18px; line-height: 1.5;">View Pull Request Code Changes</a>
    </div>
  </div>
</div>
