### PR TITLE
Fix setting softprompt via V1 API

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -10510,7 +10510,7 @@ def soft_prompt_validator(soft_prompt: str):
         raise ValidationError("Cannot use soft prompts with current backend.")
     if any(q in soft_prompt for q in ("/", "\\")):
         return
-    z, _, _, _, _ = fileops.checksp(soft_prompt.strip(), koboldai_vars.modeldim)
+    z, _, _, _, _ = fileops.checksp("./softprompts/"+soft_prompt.strip(), koboldai_vars.modeldim)
     if isinstance(z, int):
         raise ValidationError("Must be a valid soft prompt name.")
     z.close()


### PR DESCRIPTION
## Summary
Setting SP using HTTP API for a valid file name was impossible.
<img style="width:200px" src="https://user-images.githubusercontent.com/18619528/224008511-37fc22ba-6e16-46f0-9505-af72add58dcf.png">
 <img style="width:200px" src="https://user-images.githubusercontent.com/18619528/224008545-1ffec16f-0566-46f1-ab7d-8fb858612b54.png">

## Solution 
I added a missing softprompt folder path concatenation in the request validator.
<img style="width:200px" src="https://user-images.githubusercontent.com/18619528/224008790-271a619e-7400-4ab5-abbf-1d4c2906431e.png">
