### PR TITLE
Fix out of range error after editing actions

### DIFF
--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1504,9 +1504,9 @@ class KoboldStoryRegister(object):
                                 else:
                                     self.actions[i]["Probabilities"][token_num][token_option]["Used"] = False
             if "Options" in self.actions[i]:
-                for j in range(len(self.actions[i]["Options"])):
-                    if self.actions[i]["Options"][j]["text"] == text:
-                        del self.actions[i]["Options"][j]
+                for option in self.actions[i]["Options"][:]:
+                    if option["text"] == text:
+                        self.actions[i]["Options"].remove(option)
             if old_text != "":
                 self.actions[i]["Options"].append({"text": old_text, "Pinned": False, "Previous Selection": False, "Edited": True})
         else:

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1504,9 +1504,9 @@ class KoboldStoryRegister(object):
                                 else:
                                     self.actions[i]["Probabilities"][token_num][token_option]["Used"] = False
             if "Options" in self.actions[i]:
-                for option in self.actions[i]["Options"][:]:
-                    if option["text"] == text:
-                        self.actions[i]["Options"].remove(option)
+                for j in reversed(range(len(self.actions[i]["Options"]))):
+                    if self.actions[i]["Options"][j]["text"] == text:
+                        del self.actions[i]["Options"][j]
             if old_text != "":
                 self.actions[i]["Options"].append({"text": old_text, "Pinned": False, "Previous Selection": False, "Edited": True})
         else:


### PR DESCRIPTION
Problem: When updating actions, there is a `for` loop over a range of indices in an options list, but after deleting an item, it will try to access indices that no longer exist.

Steps to reproduce it in UI2:
1. Set model to ReadOnly
2. Submit the prompt "One"
3. Submit the action "Two"
4. Edit the action so it reads "TwoThree", then click away so it syncs
5. Edit the action again so it reads "TwoThreeFour", then click away to sync
6. Delete the text from step 5 so the action reads "TwoThree", click away to sync
7. Delete the text from step 4 so the action reads "Two", click away to sync
8. Check console, see this error
![Screenshot_2023-03-12_21-07-29](https://user-images.githubusercontent.com/1075900/224676481-94c1a65c-db90-41a7-900d-158fb33cd897.png)

This change reverses the range that it iterates over, so it will loop in descending order and deletions will not break the loop index