### PR TITLE
Introduce IP Whitelisting Support

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -74,6 +74,7 @@ from transformers import StoppingCriteria, GPT2Tokenizer, GPT2LMHeadModel, GPTNe
 from transformers import __version__ as transformers_version
 import transformers
 from ip_whitelist import allowed_ips
+from functools import wraps
 try:
     from transformers.models.opt.modeling_opt import OPTDecoder
 except:

--- a/aiserver.py
+++ b/aiserver.py
@@ -1529,7 +1529,7 @@ def general_startup(override_args=None):
     
     utils.args = args
     enable_whitelist = args.whitelist
-    print("Enable_Whitelist:", enable_whitelist)
+    print("Enable IP Whitelist:", enable_whitelist)
     
     #load system and user settings
     for setting in ['user_settings', 'system_settings']:

--- a/aiserver.py
+++ b/aiserver.py
@@ -73,6 +73,7 @@ import torch
 from transformers import StoppingCriteria, GPT2Tokenizer, GPT2LMHeadModel, GPTNeoForCausalLM, GPTNeoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer, PreTrainedModel, modeling_utils, AutoModelForTokenClassification
 from transformers import __version__ as transformers_version
 import transformers
+from ip_whitelist import allowed_ips
 try:
     from transformers.models.opt.modeling_opt import OPTDecoder
 except:
@@ -86,7 +87,7 @@ from PIL import Image
 from io import BytesIO
 
 global tpu_mtj_backend
-
+enable_whitelist = False
 
 if lupa.LUA_VERSION[:2] != (5, 4):
     logger.error(f"Please install lupa==1.10. You have lupa {lupa.__version__}.")
@@ -1469,8 +1470,10 @@ def spRequest(filename):
 #==================================================================#
 def general_startup(override_args=None):
     global args
+    global enable_whitelist
     # Parsing Parameters
     parser = argparse.ArgumentParser(description="KoboldAI Server")
+    parser.add_argument("--whitelist", action='store_true', default=False, help="enables IP whitelisting")
     parser.add_argument("--remote", action='store_true', help="Optimizes KoboldAI for Remote Play")
     parser.add_argument("--noaimenu", action='store_true', help="Disables the ability to select the AI")
     parser.add_argument("--ngrok", action='store_true', help="Optimizes KoboldAI for Remote Play using Ngrok")
@@ -1524,7 +1527,8 @@ def general_startup(override_args=None):
         args = parser.parse_args()
     
     utils.args = args
-
+    enable_whitelist = args.whitelist
+    print("Enable_Whitelist:", enable_whitelist)
     
     #load system and user settings
     for setting in ['user_settings', 'system_settings']:
@@ -3450,22 +3454,42 @@ def load_model(use_gpu=True, gpu_layers=None, disk_layers=None, initial_load=Fal
         print(format(colors.GREEN) + "KoboldAI has finished loading and is available at the following link for UI 1: " + koboldai_vars.cloudflare_link + format(colors.END))
         print(format(colors.GREEN) + "KoboldAI has finished loading and is available at the following link for UI 2: " + koboldai_vars.cloudflare_link + "/new_ui" + format(colors.END))
 
+
+# Setup IP Whitelisting
+# Define a function to check if IP is allowed
+def is_allowed_ip():
+    client_ip = request.remote_addr
+    return client_ip in allowed_ips
+
+# Define a decorator to enforce IP whitelisting
+def require_allowed_ip(func):
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        if enable_whitelist and not is_allowed_ip():
+            return abort(403)
+        return func(*args, **kwargs)
+    return decorated
+
 # Set up Flask routes
 @app.route('/')
 @app.route('/index')
+@require_allowed_ip
 def index():
     if args.no_ui:
         return redirect('/api/latest')
     else:
         return render_template('index.html', hide_ai_menu=args.noaimenu)
 @app.route('/api', strict_slashes=False)
+@require_allowed_ip
 def api():
     return redirect('/api/latest')
 @app.route('/favicon.ico')
+@require_allowed_ip
 def favicon():
     return send_from_directory(app.root_path,
                                    'koboldai.ico', mimetype='image/vnd.microsoft.icon')    
 @app.route('/download')
+@require_allowed_ip
 def download():
     if args.no_ui:
         raise NotFound()
@@ -8021,6 +8045,7 @@ def show_folder_usersripts(data):
 # UI V2 CODE
 #==================================================================#
 @app.route('/new_ui')
+@require_allowed_ip
 @logger.catch
 def new_ui_index():
     if args.no_ui:
@@ -8048,6 +8073,7 @@ def ui2_connect():
 # UI V2 CODE Themes
 #==================================================================#
 @app.route('/themes/<path:path>')
+@require_allowed_ip
 @logger.catch
 def ui2_serve_themes(path):
     return send_from_directory('themes', path)
@@ -8086,6 +8112,7 @@ def upload_file(data):
                     get_files_folders(session['current_folder'])
 
 @app.route("/upload_kai_story/<string:file_name>", methods=["POST"])
+@require_allowed_ip
 @logger.catch
 def UI_2_upload_kai_story(file_name: str):
 
@@ -8549,6 +8576,7 @@ def directory_to_zip_data(directory: str, overrides: Optional[dict]) -> bytes:
 # Save story to json
 #==================================================================#
 @app.route("/story_download")
+@require_allowed_ip
 @logger.catch
 def UI_2_download_story():
     if args.no_ui:
@@ -9011,6 +9039,7 @@ def UI_2_delete_wi_folder(folder):
 # Event triggered when user exports world info folder
 #==================================================================#
 @app.route('/export_world_info_folder')
+@require_allowed_ip
 @logger.catch
 def UI_2_export_world_info_folder():
     if 'folder' in request.args:
@@ -9038,6 +9067,7 @@ def UI_2_upload_world_info_folder(data):
     koboldai_vars.calc_ai_text()
 
 @app.route("/upload_wi", methods=["POST"])
+@require_allowed_ip
 @logger.catch
 def UI_2_import_world_info():
     wi_data = request.get_json()
@@ -9115,6 +9145,7 @@ def UI_2_update_wi_keys(data):
     socketio.emit("world_info_entry", koboldai_vars.worldinfo_v2.world_info[uid], broadcast=True, room="UI_2")
 
 @app.route("/set_wi_image/<int(signed=True):uid>", methods=["POST"])
+@require_allowed_ip
 @logger.catch
 def UI_2_set_wi_image(uid):
     if uid < 0:
@@ -9146,6 +9177,7 @@ def UI_2_set_wi_image(uid):
     return ":)"
 
 @app.route("/get_wi_image/<int(signed=True):uid>", methods=["GET"])
+@require_allowed_ip
 @logger.catch
 def UI_2_get_wi_image(uid):
     if args.no_ui:
@@ -9157,6 +9189,7 @@ def UI_2_get_wi_image(uid):
         return ":( Couldn't find image", 204
 
 @app.route("/set_commentator_picture/<int(signed=True):commentator_id>", methods=["POST"])
+@require_allowed_ip
 @logger.catch
 def UI_2_set_commentator_image(commentator_id):
     data = request.get_data()
@@ -9165,6 +9198,7 @@ def UI_2_set_commentator_image(commentator_id):
     return ":)"
 
 @app.route("/image_db.json", methods=["GET"])
+@require_allowed_ip
 @logger.catch
 def UI_2_get_image_db():
     if args.no_ui:
@@ -9175,6 +9209,7 @@ def UI_2_get_image_db():
         return jsonify([])
 
 @app.route("/action_composition.json", methods=["GET"])
+@require_allowed_ip
 @logger.catch
 def UI_2_get_action_composition():
     if args.no_ui:
@@ -9200,6 +9235,7 @@ def UI_2_get_action_composition():
     return jsonify(ret)
 
 @app.route("/generated_images/<path:path>")
+@require_allowed_ip
 def UI_2_send_generated_images(path):
     return send_from_directory(koboldai_vars.save_paths.generated_images, path)
 
@@ -9509,6 +9545,7 @@ def UI_2_generate_wi(data):
     socketio.emit("generated_wi", {"uid": uid, "field": field, "out": out_text}, room="UI_2")
 
 @app.route("/generate_raw", methods=["GET"])
+@require_allowed_ip
 def UI_2_generate_raw():
     prompt = request.args.get("prompt")
 
@@ -10210,6 +10247,7 @@ def UI_2_privacy_mode(data):
 # Genres
 #==================================================================#
 @app.route("/genre_data.json", methods=["GET"])
+@require_allowed_ip
 def UI_2_get_applicable_genres():
     with open("data/genres.json", "r") as file:
         genre_list = json.load(file)
@@ -10275,12 +10313,14 @@ def UI_2_get_log(data):
     emit("log_message", web_log_history)
     
 @app.route("/get_log")
+@require_allowed_ip
 def UI_2_get_log_get():
     if args.no_ui:
         return redirect('/api/latest')
     return {'aiserver_log': web_log_history}
 
 @app.route("/test_match")
+@require_allowed_ip
 @logger.catch
 def UI_2_test_match():
     koboldai_vars.assign_world_info_to_actions()
@@ -10290,6 +10330,7 @@ def UI_2_test_match():
 # Download of the audio file
 #==================================================================#
 @app.route("/audio")
+@require_allowed_ip
 @logger.catch
 def UI_2_audio():
     if args.no_ui:
@@ -10316,6 +10357,7 @@ def UI_2_audio():
 # Download of the image for an action
 #==================================================================#
 @app.route("/action_image")
+@require_allowed_ip
 @logger.catch
 def UI_2_action_image():
     if args.no_ui:
@@ -10375,6 +10417,7 @@ def model_info():
         return {"Model Type": "Read Only", "Model Size": "0", "Model Name": koboldai_vars.model.replace("_", "/")}
 
 @app.route("/vars")
+@require_allowed_ip
 @logger.catch
 def show_vars():
     if args.no_ui:

--- a/aiserver.py
+++ b/aiserver.py
@@ -1475,7 +1475,7 @@ def general_startup(override_args=None):
     global enable_whitelist
     # Parsing Parameters
     parser = argparse.ArgumentParser(description="KoboldAI Server")
-    parser.add_argument("--whitelist", nargs="+", help="Enables IP whitelisting, use a comma separated list (--whitelist 127.0.0.1, 127.0.0.2, etc)")
+    parser.add_argument("--whitelist", type=str, help="Enables IP whitelisting, use a comma separated list (--whitelist 127.0.0.1,127.0.0.2,127.0.0.3,etc)")
     parser.add_argument("--remote", action='store_true', help="Optimizes KoboldAI for Remote Play")
     parser.add_argument("--noaimenu", action='store_true', help="Disables the ability to select the AI")
     parser.add_argument("--ngrok", action='store_true', help="Optimizes KoboldAI for Remote Play using Ngrok")
@@ -1528,15 +1528,10 @@ def general_startup(override_args=None):
     else:
         args = parser.parse_args()
     
-    if args.whitelist:
-        whitelist_str = ",".join(args.whitelist)
-        allowed_ips = filter(lambda ip: ip.strip(), re.split(', *| +', whitelist_str))
-        print("Allowed IPs:", list(allowed_ips))
-    else:
-        allowed_ips = []
-
     enable_whitelist = args.whitelist is not None
+    allowed_ips = set(args.whitelist.split(",")) if enable_whitelist else set()
     print("Enable_Whitelist:", enable_whitelist)
+    print("Allowed IPs:", list(allowed_ips))
 
     
     #load system and user settings

--- a/ip_whitelist.py
+++ b/ip_whitelist.py
@@ -1,0 +1,6 @@
+allowed_ips = [
+    '127.0.0.1',
+    '192.168.0.1',
+    '10.0.0.1',
+    # Add more IP addresses as needed
+]

--- a/ip_whitelist.py
+++ b/ip_whitelist.py
@@ -1,6 +1,0 @@
-allowed_ips = [
-    '127.0.0.1',
-    '192.168.0.1',
-    '10.0.0.1',
-    # Add more IP addresses as needed
-]


### PR DESCRIPTION
Allows the user to specify IP addresses that can connect to the service. 
Useful when running --host and only wanting specific computers to have access.



