### PR TITLE
New Editor

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1476,6 +1476,18 @@ def general_startup(override_args=None):
     global args
     global enable_whitelist
     global allowed_ips
+    import configparser
+    #Figure out what git we're on if that's available
+    config = configparser.ConfigParser()
+    if os.path.exists('.git/config'):
+        config.read('.git/config')
+        koboldai_vars.git_repository = config['remote "origin"']['url']
+        for item in config.sections():
+            if "branch" in item:
+                koboldai_vars.git_branch = item.replace("branch ", "").replace('"', '')
+    
+        logger.info("Running on Repo: {} Branch: {}".format(koboldai_vars.git_repository, koboldai_vars.git_branch))
+    
     # Parsing Parameters
     parser = argparse.ArgumentParser(description="KoboldAI Server")
     parser.add_argument("--remote", action='store_true', help="Optimizes KoboldAI for Remote Play")
@@ -1602,7 +1614,7 @@ def general_startup(override_args=None):
         koboldai_vars.quiet = True
 
     if args.nobreakmodel:
-        koboldai_vars.nobreakmodel = True;
+        koboldai_vars.nobreakmodel = True
 
     if args.remote:
         koboldai_vars.host = True;
@@ -7455,17 +7467,6 @@ def loadRequest(loadpath, filename=None):
     if not loadpath:
         return
         
-    #Original UI only sends the story name and assumes it's always a .json file... here we check to see if it's a directory to load that way
-    if not os.path.exists(loadpath):
-        if os.path.exists(loadpath.replace(".json", "")):
-            loadpath = loadpath.replace(".json", "")
-
-    if os.path.isdir(loadpath):
-        if not valid_v3_story(loadpath):
-            raise RuntimeError(f"Tried to load {loadpath}, a non-save directory.")
-        koboldai_vars.update_story_path_structure(loadpath)
-        loadpath = os.path.join(loadpath, "story.json")
-
     start_time = time.time()
     # Leave Edit/Memory mode before continuing
     exitModes()
@@ -7473,6 +7474,17 @@ def loadRequest(loadpath, filename=None):
     # Read file contents into JSON object
     start_time = time.time()
     if(isinstance(loadpath, str)):
+        #Original UI only sends the story name and assumes it's always a .json file... here we check to see if it's a directory to load that way
+        if not os.path.exists(loadpath):
+            if os.path.exists(loadpath.replace(".json", "")):
+                loadpath = loadpath.replace(".json", "")
+
+        if os.path.isdir(loadpath):
+            if not valid_v3_story(loadpath):
+                raise RuntimeError(f"Tried to load {loadpath}, a non-save directory.")
+            koboldai_vars.update_story_path_structure(loadpath)
+            loadpath = os.path.join(loadpath, "story.json")
+
         with open(loadpath, "r", encoding="utf-8") as file:
             js = json.load(file)
             from_file=loadpath
@@ -8745,8 +8757,7 @@ def UI_2_back(data):
 def UI_2_redo(data):
     if koboldai_vars.aibusy:
         return
-    if len(koboldai_vars.actions.get_current_options()) == 1:
-        koboldai_vars.actions.use_option(0)
+    koboldai_vars.actions.go_forward()
     
 
 #==================================================================#

--- a/aiserver.py
+++ b/aiserver.py
@@ -7475,16 +7475,16 @@ def loadRequest(loadpath, filename=None):
     start_time = time.time()
     if(isinstance(loadpath, str)):
 		#Original UI only sends the story name and assumes it's always a .json file... here we check to see if it's a directory to load that way
-	    if not isinstance(loadpath, dict) and not os.path.exists(loadpath):
-	        if os.path.exists(loadpath.replace(".json", "")):
-	            loadpath = loadpath.replace(".json", "")
+        if not isinstance(loadpath, dict) and not os.path.exists(loadpath):
+            if os.path.exists(loadpath.replace(".json", "")):
+                loadpath = loadpath.replace(".json", "")
 
-	    if not isinstance(loadpath, dict) and os.path.isdir(loadpath):
-	        if not valid_v3_story(loadpath):
-	            raise RuntimeError(f"Tried to load {loadpath}, a non-save directory.")
-	        koboldai_vars.update_story_path_structure(loadpath)
-	        loadpath = os.path.join(loadpath, "story.json")
-        
+        if not isinstance(loadpath, dict) and os.path.isdir(loadpath):
+            if not valid_v3_story(loadpath):
+                raise RuntimeError(f"Tried to load {loadpath}, a non-save directory.")
+            koboldai_vars.update_story_path_structure(loadpath)
+            loadpath = os.path.join(loadpath, "story.json")
+            
         with open(loadpath, "r", encoding="utf-8") as file:
             js = json.load(file)
             from_file=loadpath

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1294,17 +1294,6 @@ class system_settings(settings):
         self.keep_img_gen_in_memory = False
         self.cookies = {} #cookies for colab since colab's URL changes, cookies are lost
         self.experimental_features = False
-        #check if bitsandbytes is installed
-        self.bit_8_available = False
-        if importlib.util.find_spec("bitsandbytes") is not None:# and sys.platform.startswith('linux'): #We can install bitsandbytes, but it doesn't work on windows, so limit it here
-            try:
-                import bitsandbytes
-                bits_and_bytes = True
-            except:
-                bits_and_bytes = False
-                pass
-            if torch.cuda.is_available() and bits_and_bytes:
-                self.bit_8_available = True
         self.seen_messages = []
         self.git_repository = ""
         self.git_branch = ""

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1210,7 +1210,7 @@ class system_settings(settings):
                          'lua_koboldcore', 'sp', 'sp_length', '_horde_pid', 'horde_share', 'aibusy', 
                          'serverstarted', 'inference_config', 'image_pipeline', 'summarizer', 
                          'summary_tokenizer', 'use_colab_tpu', 'noai', 'disable_set_aibusy', 'cloudflare_link', 'tts_model',
-                         'generating_image', 'bit_8_available', 'host', 'hascuda', 'usegpu', 'rng_states']
+                         'generating_image', 'bit_8_available', 'host', 'hascuda', 'usegpu', 'rng_states', 'git_repository', 'git_branch']
     settings_name = "system"
     def __init__(self, socketio, koboldai_var):
         self._socketio = socketio
@@ -1296,16 +1296,18 @@ class system_settings(settings):
         self.experimental_features = False
         #check if bitsandbytes is installed
         self.bit_8_available = False
-        if importlib.util.find_spec("bitsandbytes") is not None and sys.platform.startswith('linux'): #We can install bitsandbytes, but it doesn't work on windows, so limit it here
-            if torch.cuda.is_available():
-                for device in range(torch.cuda.device_count()):
-                    if torch.cuda.get_device_properties(device).major > 7:
-                        self.bit_8_available = True
-                        break
-                    elif torch.cuda.get_device_properties(device).major == 7 and torch.cuda.get_device_properties(device).minor >= 2:
-                        self.bit_8_available = True
-                        break
+        if importlib.util.find_spec("bitsandbytes") is not None:# and sys.platform.startswith('linux'): #We can install bitsandbytes, but it doesn't work on windows, so limit it here
+            try:
+                import bitsandbytes
+                bits_and_bytes = True
+            except:
+                bits_and_bytes = False
+                pass
+            if torch.cuda.is_available() and bits_and_bytes:
+                self.bit_8_available = True
         self.seen_messages = []
+        self.git_repository = ""
+        self.git_branch = ""
         
         
         @dataclass
@@ -1757,6 +1759,13 @@ class KoboldStoryRegister(object):
                 process_variable_changes(self._socketio, "story", 'actions', {"id": action_step, 'action':  self.actions[action_step]}, None)
                 self.set_game_saved()
     
+    def go_forward(self):
+        action_step = self.action_count+1
+        if action_step in self.actions:
+            if len(self.get_current_options()) == 1:
+                logger.warning("Going forward with this text: {}".format(self.get_current_options()[0]["text"]))
+                self.use_option([x['text'] for x in self.actions[action_step]["Options"]].index(self.get_current_options()[0]["text"]))
+    
     def use_option(self, option_number, action_step=None):
         if action_step is None:
             action_step = self.action_count+1
@@ -1800,7 +1809,8 @@ class KoboldStoryRegister(object):
             old_text = self.actions[action_id]["Selected Text"]
             old_length = self.actions[action_id]["Selected Text Length"]
             if keep:
-                self.actions[action_id]["Options"].append({"text": self.actions[action_id]["Selected Text"], "Pinned": False, "Previous Selection": True, "Edited": False})
+                if {"text": self.actions[action_id]["Selected Text"], "Pinned": False, "Previous Selection": True, "Edited": False} not in self.actions[action_id]["Options"]:
+                    self.actions[action_id]["Options"].append({"text": self.actions[action_id]["Selected Text"], "Pinned": False, "Previous Selection": True, "Edited": False})
             self.actions[action_id]["Selected Text"] = ""
             if "wi_highlighted_text" in self.actions[action_id]:
                 del self.actions[action_id]["wi_highlighted_text"]
@@ -1825,7 +1835,7 @@ class KoboldStoryRegister(object):
             
     def get_current_options(self):
         if self.action_count+1 in self.actions:
-            return self.actions[self.action_count+1]["Options"]
+            return [x for x in self.actions[self.action_count+1]["Options"] if x['Edited'] != True]
         else:
             return []
             

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -3680,4 +3680,7 @@ select {
 	text-decoration: underline dotted;
 }
 
+.dirty {
+	text-decoration: underline dotted red;
+}
 

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -80,6 +80,7 @@ var generating_summary = false;
 const on_colab = $el("#on_colab").textContent == "true";
 let story_id = -1;
 var dirty_chunks = [];
+var initial_socketio_connection_occured = false;
 
 // Each entry into this array should be an object that looks like:
 // {class: "class", key: "key", func: callback}
@@ -218,6 +219,10 @@ var current_action;
 function connect() {
 	console.log("connected");
 	//reset_story();
+	if (initial_socketio_connection_occured) {
+		location.reload();
+	}
+	initial_socketio_connection_occured = true;
 	for (item of document.getElementsByTagName("body")) {
 		item.classList.remove("NotConnected");
 	}

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -262,6 +262,7 @@ function disruptStoryState() {
 
 function reset_story() {
 	console.log("Resetting story");
+	location.reload();
 	disruptStoryState();
 	chunk_delete_observer.disconnect();
 	clearTimeout(calc_token_usage_timeout);

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3085,12 +3085,12 @@ function gametextwatcher(records) {
 						if (!dirty_chunks.includes(chunk.getAttribute("chunk"))) {
 							dirty_chunks.push(chunk.getAttribute("chunk"));
 							//Stupid firefox sometimes looses focus as you type after deleting stuff. Fix that here
-							//var sel = window.getSelection();
-							//if (sel.anchorNode instanceof HTMLElement) {
-							//	sel.anchorNode.focus();
-							//} else {
-							//	game_text.focus();
-							//}
+							var sel = window.getSelection();
+							if (sel.anchorNode instanceof HTMLElement) {
+								sel.anchorNode.focus();
+							} else {
+								game_text.focus();
+							}
 						}
 					}
 				}

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3060,8 +3060,11 @@ function gametextwatcher(records) {
 	for (const record of records) {
 		if ((record.type === "childList") && (record.removedNodes.length > 0)) {
 			for (const chunk of record.removedNodes) {
+				//we've deleted a node. Let's find the chunk span and put it back
+				//Skip over deletes that are not chunks
 				if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
 					if (!document.getElementById("Selected Text Chunk " + chunk.getAttribute("chunk"))) {
+						//Node was actually deleted. Now let's figure out where to put it back (could be in the middle)
 						chunk.innerText = '';
 						var found = -1
 						for (let i = parseInt(chunk.getAttribute("chunk"))-1; i > -1; i--) { 
@@ -3083,6 +3086,12 @@ function gametextwatcher(records) {
 							game_text.append(chunk);
 						}
 						chunk.classList.add("dirty");
+					} else {
+						//For some reason we've deleted a chunk but it still exists in the DOM. Something is wrong here
+						//Seems to loose the events on the item, but otherwise is OK. DEPLOY HACK!!!
+						document.getElementById("Selected Text Chunk " + chunk.getAttribute("chunk")).addEventListener("focus", (event) => {
+							set_edit(event.target);
+						});
 					}
 				}
 			}

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3147,7 +3147,7 @@ function fix_dirty_game_text() {
 		console.log("Firing Fix messed up text");
 		//Fixing text outside of chunks
 		for (node of game_text.childNodes) {
-			if ((!(node instanceof HTMLElement) || !node.hasAttribute("chunk")) && (node.wholeText.trim() != "")) {
+			if ((!(node instanceof HTMLElement) || !node.hasAttribute("chunk")) && (node.textContent.trim() != "")) {
 				console.log("Found Node that needs to be combined");
 				console.log(node);
 				//We have a text only node. It should be moved into the previous chunk

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -286,8 +286,6 @@ function reset_story() {
 	for (const item of temp) { 
 		item.remove();
 	}
-	//document.getElementById("Selected Text").setAttribute("contenteditable", "false");
-	document.getElementById("story_prompt").setAttribute("contenteditable", "false");
 	
 	//clear any options
 	var option_area = document.getElementById("Select Options");
@@ -316,8 +314,11 @@ function reset_story() {
 		text += "\xa0 ";
 	}
 	document.getElementById("welcome_text").innerText = text;
+	document.getElementById("Selected Text").setAttribute("contenteditable", "false");
 	if (document.getElementById("story_prompt").innerText == "") {
 		document.getElementById("welcome_container").classList.remove("hidden");
+		document.getElementById("Selected Text").setAttribute("contenteditable", "true");
+		
 	}
 	document.getElementById('main-grid').setAttribute('option_length', 0);
 
@@ -679,7 +680,6 @@ function do_prompt(data) {
 		document.getElementById('themerow').classList.remove("hidden");
 		addInitChatMessage();
 	}
-	document.getElementById("story_prompt").classList.remove("dirty");
 	
 }
 

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3097,6 +3097,7 @@ function gametextwatcher(records) {
 							game_text.append(chunk);
 						}
 						chunk.classList.add("dirty");
+						did_deletes = true;
 					} else {
 						//For some reason we've deleted a chunk but it still exists in the DOM. Something is wrong here
 						//Seems to loose the events on the item, but otherwise is OK. DEPLOY HACK!!!
@@ -3127,6 +3128,9 @@ function gametextwatcher(records) {
 				temp.focus();
 			}
 		}
+	}
+	if (did_deletes) {
+		savegametextchanges();
 	}
 }
 

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -566,9 +566,9 @@ function do_story_text_updates(action) {
 			item.classList.add("rawtext");
 			item.setAttribute("chunk", action.id);
 			item.setAttribute("tabindex", parseInt(action.id)+1);
-			item.addEventListener("focus", (event) => {
-				set_edit(event.target);
-			});
+			//item.addEventListener("focus", (event) => {
+			//	set_edit(event.target);
+			//});
 			
 			//need to find the closest element
 			closest_element = document.getElementById("story_prompt");
@@ -3044,11 +3044,23 @@ function toggle_adventure_mode(button) {
 	
 }
 
-function set_edit(element) {
-	for (item of document.getElementsByClassName("editing")) {
-		item.classList.remove("editing");
+function set_edit(event) {
+	//get the element sitting on
+	var game_text = document.getElementById("Selected Text");
+	if ((event.key === undefined) || (event.key == 'ArrowDown') || (event.key == 'ArrowUp') || (event.key == 'ArrowLeft') || (event.key == 'ArrowRight')) {
+		var chunk = window.getSelection().anchorNode;
+		while (chunk != game_text) {
+			if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
+				break;
+			}
+			chunk = chunk.parentNode;
+		}
+		for (item of document.getElementsByClassName("editing")) {
+			item.classList.remove("editing");
+		}
+		chunk.classList.add("editing");
 	}
-	element.classList.add("editing");
+	return true;
 }
 
 function gametextwatcher(records) {
@@ -3089,9 +3101,9 @@ function gametextwatcher(records) {
 					} else {
 						//For some reason we've deleted a chunk but it still exists in the DOM. Something is wrong here
 						//Seems to loose the events on the item, but otherwise is OK. DEPLOY HACK!!!
-						document.getElementById("Selected Text Chunk " + chunk.getAttribute("chunk")).addEventListener("focus", (event) => {
-							set_edit(event.target);
-						});
+						//document.getElementById("Selected Text Chunk " + chunk.getAttribute("chunk")).addEventListener("focus", (event) => {
+						//	set_edit(event.target);
+						//});
 					}
 				}
 			}

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3065,6 +3065,10 @@ function set_edit(event) {
 	return true;
 }
 
+function check_game_after_paste() {
+	setTimeout(function() {savegametextchanges();}, 500);
+}
+
 function gametextwatcher(records) {
 	//Here we want to take care of two possible events
 	//User deleted an action. For this we'll restore the action and set it's text to "" and mark it as dirty

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -316,7 +316,9 @@ function reset_story() {
 		text += "\xa0 ";
 	}
 	document.getElementById("welcome_text").innerText = text;
-	document.getElementById("welcome_container").classList.remove("hidden");
+	if (document.getElementById("story_prompt").innerText == "") {
+		document.getElementById("welcome_container").classList.remove("hidden");
+	}
 	document.getElementById('main-grid').setAttribute('option_length', 0);
 
 	$(".chat-message").remove();

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3109,23 +3109,42 @@ function gametextwatcher(records) {
 			}
 		} else {
 			var chunk = record.target;
-			var skip = true;
+			var found_chunk = false;
 			while (chunk != game_text) {
-				if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
-					skip = false;
+				if (chunk) {
+					if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
+						found_chunk = true;
+						break;
+					}
+					chunk = chunk.parentNode;
+				} else {
 					break;
 				}
-				chunk = chunk.parentNode;
 			}
-			if ((chunk.original_text != chunk.innerText) && (!skip)) {;
+			if ((found_chunk) && (chunk.original_text != chunk.innerText)) {;
 				chunk.classList.add("dirty");
-			} else if ((record.addedNodes.length > 0) && (record.addedNodes[0].parentNode == game_text) && !(record.addedNodes[0] instanceof HTMLElement)) {
+			} else if ((record.addedNodes.length > 0) && !(found_chunk) && !(record.addedNodes[0] instanceof HTMLElement)) {
 				//Here we added a text node directly under game text. We should move it to be in the previous chunk
-				record.addedNodes[0].previousElementSibling.innerText = record.addedNodes[0].previousElementSibling.innerText + record.addedNodes[0].data;
-				record.addedNodes[0].previousElementSibling.classList.add("dirty");
-				var temp = record.addedNodes[0].previousElementSibling;
-				record.addedNodes[0].remove();
-				temp.focus();
+				var chunk = record.addedNodes[0];
+				found_chunk = false;
+				while (chunk != game_text) {
+					if (chunk) {
+						if (chunk.parentNode === game_text) {
+							found_chunk = true;
+							break;
+						}
+						chunk = chunk.parentNode;
+					} else {
+						break;
+					}
+				}
+				if (found_chunk) {
+					chunk.previousElementSibling.innerText = chunk.previousElementSibling.innerText + record.addedNodes[0].data;
+					chunk.previousElementSibling.classList.add("dirty");
+					var temp = chunk.previousElementSibling;
+					chunk.remove();
+					temp.focus();
+				}
 			}
 		}
 	}

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3080,36 +3080,44 @@ function gametextwatcher(records) {
 						//Node was actually deleted. 
 						if (!dirty_chunks.includes(chunk.getAttribute("chunk"))) {
 							dirty_chunks.push(chunk.getAttribute("chunk"));
+							//Stupid firefox sometimes looses focus as you type after deleting stuff. Fix that here
+							//var sel = window.getSelection();
+							//if (sel.anchorNode instanceof HTMLElement) {
+							//	sel.anchorNode.focus();
+							//} else {
+							//	game_text.focus();
+							//}
 						}
 					}
 				}
 			}
-		} else {
-			//get the actual chunk rather than the sub-node
-			var chunk = record.target;
-			var found_chunk = false;
-			while (chunk != game_text) {
-				if (chunk) {
-					if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
-						found_chunk = true;
-						break;
-					}
-					chunk = chunk.parentNode;
-				} else {
+		}
+		//get the actual chunk rather than the sub-node
+		//console.log(record);
+		var chunk = record.target;
+		var found_chunk = false;
+		while (chunk != game_text) {
+			if (chunk) {
+				if ((chunk instanceof HTMLElement) && (chunk.hasAttribute("chunk"))) {
+					found_chunk = true;
 					break;
 				}
+				chunk = chunk.parentNode;
+			} else {
+				break;
 			}
-			if ((found_chunk) && (chunk.original_text != chunk.innerText)) {;
-				if (!dirty_chunks.includes(chunk.getAttribute("chunk"))) {
-					dirty_chunks.push(chunk.getAttribute("chunk"));
-				}
-			} else if ((record.addedNodes.length > 0) && !(found_chunk) && !(record.addedNodes[0] instanceof HTMLElement)) {
-				if (!dirty_chunks.includes("game_text")) {
-					dirty_chunks.push("game_text");
-				}
+		}
+		if ((found_chunk) && (chunk.original_text != chunk.innerText)) {;
+			if (!dirty_chunks.includes(chunk.getAttribute("chunk"))) {
+				dirty_chunks.push(chunk.getAttribute("chunk"));
+			}
+		} else if ((record.addedNodes.length > 0) && !(found_chunk) && !(record.addedNodes[0] instanceof HTMLElement)) {
+			if (!dirty_chunks.includes("game_text")) {
+				dirty_chunks.push("game_text");
 			}
 		}
 	}
+	//console.log(dirty_chunks);
 }
 
 function fix_dirty_game_text() {
@@ -3133,7 +3141,7 @@ function fix_dirty_game_text() {
 		console.log("Firing Fix messed up text");
 		//Fixing text outside of chunks
 		for (node of game_text.childNodes) {
-			if (!(node instanceof HTMLElement) || !node.hasAttribute("chunk")) {
+			if ((!(node instanceof HTMLElement) || !node.hasAttribute("chunk")) && (node.wholeText.trim() != "")) {
 				console.log("Found Node that needs to be combined");
 				console.log(node);
 				//We have a text only node. It should be moved into the previous chunk

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -44,7 +44,6 @@ initalizeTooltips();
 //setup an observer on the game text
 var chunk_delete_observer = new MutationObserver(function (records) {gametextwatcher(records)});
 
-chunk_delete_observer.observe(document.getElementById('Selected Text'), { subtree: true, childList: true, characterData: true });
 
 var vars_sync_time = {};
 var presets = {};

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3058,7 +3058,9 @@ function set_edit(event) {
 		for (item of document.getElementsByClassName("editing")) {
 			item.classList.remove("editing");
 		}
-		chunk.classList.add("editing");
+		if (chunk != game_text) {
+			chunk.classList.add("editing");
+		}
 	}
 	return true;
 }
@@ -3161,7 +3163,7 @@ function savegametextchanges() {
 		if (chunk_id == -1) {
 			chunk = document.getElementById("story_prompt");
 		} else {
-			chunk = document.getElementById("Selected Text Chunk " + chunk);
+			chunk = document.getElementById("Selected Text Chunk " + chunk_id);
 		}
 		if (chunk) {
 			update_game_text(parseInt(chunk.getAttribute("chunk")), chunk.innerText);

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -320,7 +320,7 @@ function reset_story() {
 	$(".chat-message").remove();
 	addInitChatMessage();
 	
-	chunk_delete_observer.observe(document.getElementById('Selected Text'), { childList: true });
+	chunk_delete_observer.observe(document.getElementById('Selected Text'), { subtree: true, childList: true, characterData: true });
 }
 
 function fix_text(val) {

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,7 +53,7 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false onblur="select_game_text(null);" onclick="select_game_text(null);" onkeyup="select_game_text(event);">
+			<div class="gametext" id="Selected Text" contenteditable=false onblur="select_game_text(null);" onclick="select_game_text(null);" onkeyup="select_game_text(event);" onpaste="capturegametextpaste(event);">
 				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,8 +53,8 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();">
-				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1" onfocus="set_edit(this);"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
+			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onclick="return set_edit(event)" onkeyup="return set_edit(event)">
+				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 
 		<!------------ Sequences --------------------->

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,8 +53,9 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false onblur="select_game_text(null);" onclick="select_game_text(null);" onkeyup="select_game_text(event);" onpaste="capturegametextpaste(event);">
-				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
+			<!---<div class="gametext" id="Selected Text" contenteditable=false onfocusin="select_game_text('focusin');" onfocusout="select_game_text('focusout');" onclick="select_game_text(null);" onkeyup="select_game_text(event);" onpaste="capturegametextpaste(event);">-->
+			<div class="gametext" id="Selected Text" contenteditable=false onpaste="capturegametextpaste(event);">
+				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1" onfocus="set_edit(this);" onblur="select_game_text(null, this, 'onblur prompt');"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 
 		<!------------ Sequences --------------------->

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,7 +53,7 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onclick="return set_edit(event)" onkeyup="return set_edit(event);">
+			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onpaste="check_game_after_paste()" onfocusout="savegametextchanges();" onclick="return set_edit(event)" onkeyup="return set_edit(event);">
 				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,8 +53,8 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onpaste="capturegametextpaste(event);">
-				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
+			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();">
+				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1" onfocus="set_edit(this);"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 
 		<!------------ Sequences --------------------->

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -27,7 +27,7 @@
 	<script src="static/favicon.js"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
-<body>
+<body onload="chunk_delete_observer.observe(document.getElementById('Selected Text'), { subtree: true, childList: true, characterData: true });">
 	<span class="hidden var_sync_system_on_colab" id="on_colab">false</span>
 	<!------------ Left Flyout Menu--------------------->
 	<div id="SideMenu" class="SideMenu pinned">

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,9 +53,8 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<!---<div class="gametext" id="Selected Text" contenteditable=false onfocusin="select_game_text('focusin');" onfocusout="select_game_text('focusout');" onclick="select_game_text(null);" onkeyup="select_game_text(event);" onpaste="capturegametextpaste(event);">-->
-			<div class="gametext" id="Selected Text" contenteditable=false onpaste="capturegametextpaste(event);">
-				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1" onfocus="set_edit(this);" onblur="select_game_text(null, this, 'onblur prompt');"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
+			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onpaste="capturegametextpaste(event);">
+				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" tabindex=0 chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 
 		<!------------ Sequences --------------------->

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -53,7 +53,7 @@
 				<div id="welcome_text" class="var_sync_model_welcome" draggable="False"></div>
 			</div>
 
-			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onclick="return set_edit(event)" onkeyup="return set_edit(event)">
+			<div class="gametext" id="Selected Text" contenteditable=false tabindex=0 onfocusout="savegametextchanges();" onclick="return set_edit(event)" onkeyup="return set_edit(event);">
 				<span id="story_prompt" class="var_sync_story_prompt var_sync_alt_story_prompt_in_ai rawtext hidden" chunk="-1"></span></div><!--don't move the /div down or it'll cause odd spacing issues in the UI--->
 		</div>
 

--- a/templates/popups.html
+++ b/templates/popups.html
@@ -71,7 +71,7 @@
 				<input type="checkbox" data-toggle="toggle" data-onstyle="success" id="use_gpu" checked>
 				<div class="box-label">Use GPU</div>
 			</div>
-			<div class="box flex-push-right hidden" id=use_8_bit_div>
+			<div class="box flex-push-right hidden" id=use_8_bit_div onclick="set_8_bit_mode()">
 				<input type="checkbox" data-toggle="toggle" data-onstyle="success" id="use_8_bit" checked>
 				<div class="box-label">Use 8 bit mode</div>
 			</div>
@@ -400,6 +400,21 @@
 
 		<div id="sw-download">Download Screenshot</div>
 	</div>
+	
+	<!---------------- version screen ---------------------->
+	<div id="version-popup" class="popup-window popup">
+		<div class="title">
+			<div class="popuptitletext">Version</div>
+		</div>
+		<div id="popup_list_area" class="popup_list_area" style="overflow-x: scroll;">
+			<div>Git Repository: <span class="var_sync_system_git_repository"></span></div>
+			<div>Git Branch: <span class="var_sync_system_git_branch"></span></div>
+		</div>
+		<div class="popup_load_cancel">
+			<button type="button" class="btn btn-primary popup_load_cancel_button" onclick="closePopups();">Ok</button>
+		</div>
+	</div>
+	
 </div>
 
 <div id="notification-container"></div>

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -488,7 +488,8 @@
 	</div>
 	<div id="settings_footer" class="settings_footer">
 		<span>Execution Time: <span id="Execution Time"></span></span> | 
-		<span>Remaining Time: <span class="var_sync_model_tqdm_rem_time"></span></span> | <span class="var_sync_actions_Action_Count"></span>
-		<a onclick='socket.emit("get_log", {});openPopup("log-popup");' class='cursor'>Log</a>
+		<span>Remaining Time: <span class="var_sync_model_tqdm_rem_time"></span></span> | 
+		<a onclick='socket.emit("get_log", {});openPopup("log-popup");' class='cursor'>Log</a> |
+		<a onclick='openPopup("version-popup");' class='cursor'>Version</a>
 	</div>
 </div>

--- a/templates/settings item.html
+++ b/templates/settings item.html
@@ -12,7 +12,7 @@
 	{% if (item['unit'] != 'bool') and (item['unit'] != 'text') and (item['uitype'] != 'dropdown') %}
 		<input autocomplete="off" class="setting_value var_sync_{{ item['classname'] }}_{{ item['name'] }}" id="{{ item['classname'] }}_{{ item['name'] }}_cur"
 			   value="{{ item['default'] }}" item_id="{{ item['classname'] }}_{{ item['name'] }}" 
-			   {% if item['unit'] == 'float' %} inputmode="decimal"{% elif item['unit'] == 'float' %} inputmode="numeric"{% endif %}
+			   {% if item['unit'] == 'float' %} inputmode="decimal"{% elif item['unit'] == 'int' %} inputmode="numeric"{% endif %}
 			   onchange="document.getElementById(this.getAttribute('item_id')).value = this.value; socket.emit('var_change', {'ID': this.id.replace('_cur', ''), 'value': this.value});">
 	{% endif %}
 	<!---Bottom Row---->


### PR DESCRIPTION
Rewritten editor code to use mutation observers. This should give move accurate text change detection.
New method does the following:
- Mutation observer on all elements under the Selected Text div for deleted elements, added elements, and changed text
- When an element is deleted, it's added back in with the text content changed to '' and a class added to the chunk of "dirty"
- When the text changes it adds the class "dirty" to the chunk
- When the selected text div looses focus is looks for dirty chunks and saves them
In testing this is cleaner and sends fewer changes to the server (more batched changes when you're done editing. 

Other minor changes:
- Includes a version popup in UI2 that shows which git/branch you're running on. Link is in the left flyout at the bottom.
- Fix for changing text then back/forward a bunch loosing text
- Fix for welcome text area showing up when it shouldn't