### PR TITLE
Fix phantom 8 bit variable

### DIFF
--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -684,6 +684,7 @@ class model_settings(settings):
         self.welcome     = self.welcome_default
         self._koboldai_vars = koboldai_vars
         self.alt_multi_gen = False
+        self.bit_8_available = None
         
     def reset_for_model_load(self):
         self.simple_randomness = 0 #Set first as this affects other outputs


### PR DESCRIPTION
Somehow this gets added to the vars for most existing installations, making this hard to find. This variable is sent to the client for display on model selection, which is a problem if it doesnt exist