### PR TITLE
Basic PEFT support

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -1345,6 +1345,7 @@ def general_startup(override_args=None):
     parser.add_argument("--summarizer_model", action='store', default="philschmid/bart-large-cnn-samsum", help="Huggingface model to use for summarization. Defaults to sshleifer/distilbart-cnn-12-6")
     parser.add_argument("--max_summary_length", action='store', default=75, help="Maximum size for summary to send to image generation")
     parser.add_argument("--multi_story", action='store_true', default=False, help="Allow multi-story mode (experimental)")
+    parser.add_argument("--peft", type=str, help="Specify the path or HuggingFace ID of a Peft to load it. Not supported on TPU. (Experimental)")
     
     parser.add_argument('-f', action='store', help="option for compatability with colab memory profiles")
     parser.add_argument('-v', '--verbosity', action='count', default=0, help="The default logging level is ERROR or higher. This value increases the amount of logging seen in your screen")

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -45,3 +45,4 @@ dependencies:
     - ftfy
     - pydub
     - diffusers
+    - peft==0.3.0

--- a/environments/huggingface.yml
+++ b/environments/huggingface.yml
@@ -33,7 +33,7 @@ dependencies:
     - lupa==1.10
     - transformers==4.28.0
     - huggingface_hub==0.12.1
-    - safetensors
+    - safetensors==0.3.1
     - accelerate==0.18.0
     - git+https://github.com/VE-FORBRYDERNE/mkultra
     - flask-session

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -41,3 +41,4 @@ dependencies:
     - ftfy
     - pydub
     - diffusers
+    - peft==0.3.0

--- a/environments/rocm.yml
+++ b/environments/rocm.yml
@@ -32,7 +32,7 @@ dependencies:
     - lupa==1.10
     - transformers==4.28.0
     - huggingface_hub==0.12.1
-    - safetensors
+    - safetensors==0.3.1
     - accelerate==0.18.0
     - git+https://github.com/VE-FORBRYDERNE/mkultra
     - ansi2html

--- a/models/peft/README.txt
+++ b/models/peft/README.txt
@@ -1,0 +1,2 @@
+PEFT models will be stored in this directory when downloaded.
+Please don't be too mean to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ pytest-html==3.2.0
 pytest-metadata==2.0.4
 requests-mock==1.10.0
 safetensors==0.3.1
+peft==0.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ pytest==7.2.2
 pytest-html==3.2.0
 pytest-metadata==2.0.4
 requests-mock==1.10.0
-safetensors
+safetensors==0.3.1


### PR DESCRIPTION
This PR adds basic support for Hugging Face PEFT models. One can be loaded by passing in the `--peft` flag with either a Hugging Face repo ID or a local path.

This PR also clamps the Safetensors version to a known working one in case of breaking changes.