### PR TITLE
Accept wi type in UI_2_edit_world_info when adding an entry

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -6537,11 +6537,12 @@ def UI_2_edit_world_info(data):
     
     if data['uid'] < 0:
         logger.debug("Creating WI: {}".format(data))
-        koboldai_vars.worldinfo_v2.add_item(data['title'], data['key'], 
-                                             data['keysecondary'], data['folder'], 
+        koboldai_vars.worldinfo_v2.add_item(data['title'], data['key'],
+                                             data['keysecondary'], data['folder'],
                                              data['constant'], data['manual_text'], 
-                                             data['comment'], wpp=data['wpp'],
-                                             use_wpp=data['use_wpp'], object_type=data["object_type"])
+                                             data['comment'], wi_type=data["type"],
+                                             wpp=data['wpp'], use_wpp=data['use_wpp'],
+                                             object_type=data["object_type"])
         emit("delete_new_world_info_entry", {})
     else:
         logger.debug("Editting WI: {}".format(data))


### PR DESCRIPTION
For some reason, `add_item` accepts a `wi_type` parameter but it's never provided when called. This breaks the ability to do a few things on a socket-based client:
- Initialize a new WI entry with anything other than "keywords" as the default
- Add a new WI entry based on previously saved WI data

This change adds `wi_type=data["type"]` to the `add_item`  call, making it almost identical to the way `edit_item` is called (other than the uid which doesn't exist yet)