### PR TITLE
Configurable quantization level, fix for broken toggles in model settings

### DIFF
--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -2011,7 +2011,7 @@ function load_model() {
 	data = {}
 	if (settings_area) {
 		for (const element of settings_area.querySelectorAll(".model_settings_input:not(.hidden)")) {
-			var element_data = element.value;
+			var element_data = element.getAttribute("data_type") === "bool" ? element.checked : element.value;
 			if ((element.tagName == "SELECT") && (element.multiple)) {
 				element_data = [];
 				for (var i=0, iLen=element.options.length; i<iLen; i++) {
@@ -2024,8 +2024,6 @@ function load_model() {
 					element_data = parseInt(element_data);
 				} else if (element.getAttribute("data_type") == "float") {
 					element_data = parseFloat(element_data);
-				} else if (element.getAttribute("data_type") == "bool") {
-					element_data = (element_data == 'on');
 				}
 			}
 			data[element.id.split("|")[1].replace("_value", "")] = element_data;


### PR DESCRIPTION
- Removes the 4bit toggle and replaces it with a quantization dropdown which can hold the values "none" | "4bit" | "8bit"
- Fix an issue where toggles were not turning off correctly due to the `value` property being checked instead of the `checked` property. To reproduce the issue, select any `<input type="checkbox" data-toggle="toggle">` in an inspector and notice that `$0.value` is always `"on"` regardless of the UI state.