### PR TITLE
Workaround for option panel popping up too much

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -3902,6 +3902,10 @@ def generate(txt, minimum, maximum, found_entries=None):
     # Open up token stream
     emit("stream_tokens", True, broadcast=True, room="UI_2")
 
+    # HACK: Show options when streaming more than 1 sequence
+    if utils.koboldai_vars.output_streaming:
+        koboldai_vars.actions.show_options(koboldai_vars.numseqs > 1, force=True)
+
     koboldai_vars.generated_tkns = 0
 
     if(found_entries is None):
@@ -6166,6 +6170,7 @@ def UI_2_Set_Selected_Text(data):
 @socketio.on('Use Option Text')
 @logger.catch
 def UI_2_Use_Option_Text(data):
+    koboldai_vars.actions.show_options(False)
     if koboldai_vars.prompt == "":
         koboldai_vars.prompt = koboldai_vars.actions.get_current_options()[int(data['option'])]['text']
         koboldai_vars.actions.clear_unused_options()

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -1528,7 +1528,7 @@ body {
 	grid-template-columns: 30px auto 30% 30px;
 	grid-template-rows: auto min-content min-content 100px;
 }
-.main-grid[option_length="0"][model_numseqs="1"] {
+.main-grid[hide-options="true"] {
 	grid-template-columns: 30px auto 0px 30px;
 }
 
@@ -1613,39 +1613,39 @@ body {
 	font-style: italic;
 }
 
-.sequence_area {
+#option-container {
 	margin-top: 10px;
 	grid-area: options;
 	background-color: var(--sequence_area_background);
 	overflow-y: scroll;
 }
 
-.sequence_area::-webkit-scrollbar {
+#option-container::-webkit-scrollbar {
 	display: none;
 }
 
 @media only screen and (max-aspect-ratio: 7/5) {
-.sequences {
-	margin-top: 5px;
-	width: 100%;
-	border: 0px;
-	border-spacing: 0;
-	display: flex;
-	flex-direction: row;
-	overflow-x: scroll;
-	scroll-snap-type: x mandatory;
-}
+	#option-container {
+		margin-top: 5px;
+		width: 100%;
+		border: 0px;
+		border-spacing: 0;
+		display: flex;
+		flex-direction: row;
+		overflow-x: scroll;
+		scroll-snap-type: x mandatory;
+	}
 }
 
 @media only screen and (min-aspect-ratio: 7/5) {
-.sequences {
-	margin-top: 5px;
-	width: 100%;
-	border: 0px;
-	border-spacing: 0;
-	display: flex;
-	flex-direction: column;
-}
+	#option-container {
+		margin-top: 5px;
+		width: 100%;
+		border: 0px;
+		border-spacing: 0;
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .sequence_row {

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -44,7 +44,7 @@
 	</div>
 
 	<!------------ Main Screen--------------------->
-	<div id="main-grid" class="main-grid settings_pinned var_sync_alt_model_numseqs" onclick="close_menus();" option_length="0">
+	<div id="main-grid" class="main-grid settings_pinned var_sync_alt_model_numseqs" onclick="close_menus();" hide-options="true">
 		<!------------ Game Text Screen--------------------->
 		<div class="gamescreen" id="gamescreen" context-menu="gamescreen">
 			<div id="disconnect_message"><center><h1>Disconnected</h1></center></div>
@@ -59,7 +59,7 @@
 
 		<!------------ Sequences --------------------->
 		<div id="action_count" class="var_sync_actions_Action_Count hidden"></div>
-		<div id="Select Options" class="sequence_area"></div>
+		<div id="option-container" class="hidden"></div>
 
 		<!-- Story Review -->
 		<div id="story-review" class="hidden">


### PR DESCRIPTION
The current behavior of the option panel is to open whenever the options for the latest action change (eg, options changed themselves, multigen streaming, action changes, etc). This implicit opening isnt great because its hard to control when the option panel opens.

This workaround alleviates part of the problem by explicitly declaring if the options panel should open on the server in some key places. This is less ideal than an invasive fix, and less invasive than an ideal fix. probably needs gnarly testing