### PR TITLE
Fix for options not showing up on refresh

### DIFF
--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -94,7 +94,7 @@ var supported_gen_modes = [];
 var privacy_mode_enabled = false;
 var attention_wanting_wi_bar = null;
 var ai_busy = false;
-var can_show_options = false;
+var can_show_options = true;
 
 var streaming = {
 	windowOpen: false,

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3448,7 +3448,6 @@ function fix_dirty_game_text() {
 }
 
 function savegametextchanges() {
-	console.log("Saving game text");
 	fix_dirty_game_text();
 	for (const item of document.getElementsByClassName("editing")) {
 		item.classList.remove("editing");

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -94,7 +94,7 @@ var supported_gen_modes = [];
 var privacy_mode_enabled = false;
 var attention_wanting_wi_bar = null;
 var ai_busy = false;
-var can_show_options = false;
+var can_show_options = true;
 
 var streaming = {
 	windowOpen: false,
@@ -3448,6 +3448,7 @@ function fix_dirty_game_text() {
 }
 
 function savegametextchanges() {
+	console.log("Saving game text");
 	fix_dirty_game_text();
 	for (const item of document.getElementsByClassName("editing")) {
 		item.classList.remove("editing");


### PR DESCRIPTION
When a user generates text options using multi-gen, then refreshes the browser all options are lost to the user. These options should stay on the page until one is selected. 