### PR TITLE
fix(load_json): use int action id

### DIFF
--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1608,11 +1608,11 @@ class KoboldStoryRegister(object):
             if "image_gen" not in json_data["actions"][item]:
                 json_data["actions"][item]["image_gen"] = False
 
+            action_id = int(item)
+            temp[action_id] = json_data['actions'][item]
+            if action_id >= self.action_count-100: #sending last 100 items to UI
+                data_to_send.append({"id": action_id, 'action':  temp[action_id]})
 
-            temp[int(item)] = json_data['actions'][item]
-            if int(item) >= self.action_count-100: #sending last 100 items to UI
-                data_to_send.append({"id": item, 'action':  temp[int(item)]})
-        
         process_variable_changes(self._socketio, "story", 'actions', data_to_send, None)
         
         self.actions = temp


### PR DESCRIPTION
When a story is loaded from JSON, it currently does not convert the action IDs to ints. It looks like Kobold prevents this from causing issues by refreshing the page, but in Ghostpad I've noticed catastrophic bugs resulting from it.

First a story is loaded and string-based IDs get loaded in state

<img width="265" alt="Screenshot 2023-11-10 at 04 49 45" src="https://github.com/henk717/KoboldAI/assets/1075900/801d719a-64d9-4ada-a337-276d504bab7a">

Then as the story is edited, it (correctly) stores those changes using int based IDs
<img width="268" alt="Screenshot 2023-11-10 at 04 48 25" src="https://github.com/henk717/KoboldAI/assets/1075900/9d57cc8d-5375-4edb-a86f-2e86c1166342">

And that's where things get very broken.

This PR makes two small changes to `load_json`:
1. Store the int based action id in a variable called `action_id` so we don't have to cast it 4+ times
2. Use the int based action id in the data that gets sent to `process_variable_changes`

I could work around this on the frontend, but I think it makes more sense to have consistent types being sent over the socket