### PR TITLE
Update BigDL and add commandline-ipex.sh

### DIFF
--- a/commandline-ipex.sh
+++ b/commandline-ipex.sh
@@ -1,0 +1,14 @@
+if [ ! -x "$(command -v sycl-ls)" ]
+then
+    echo "Setting OneAPI environment"
+    if [[ -z "$ONEAPI_ROOT" ]]
+    then
+        ONEAPI_ROOT=/opt/intel/oneapi
+    fi
+    source $ONEAPI_ROOT/setvars.sh
+fi
+export CONDA_AUTO_ACTIVATE_BASE=false
+export PYTHONNOUSERSITE=1
+export NEOReadDebugKeys=1
+export ClDeviceGlobalMemSizeAvailablePercent=100
+bin/micromamba run -r runtime -n koboldai-ipex bash

--- a/environments/ipex.yml
+++ b/environments/ipex.yml
@@ -1,5 +1,6 @@
 name: koboldai
 channels:
+  - pytorch
   - conda-forge
   - defaults
 dependencies:
@@ -29,8 +30,9 @@ dependencies:
     - --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
     - torch==2.1.0a0; sys_platform == 'linux'
     - intel-extension-for-pytorch==2.1.10+xpu; sys_platform == 'linux'
-    - bigdl-llm
-    - bigdl_core_xe
+    - bigdl-llm==2.5.0b20231218
+    - bigdl-core-xe-21==2.5.0b20231218
+    - py-cpuinfo
     - openvino
     - onnxruntime-openvino
     - flask-cloudflared==0.0.10


### PR DESCRIPTION
No need to downgrade IPEX and OneAPI anymore.
Should be updated again with the next stable release since nightly builds aren't permanent.