### PR TITLE
Instruction mode

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -6172,7 +6172,6 @@ def UI_2_delete_option(data):
 @socketio.on('submit')
 @logger.catch
 def UI_2_submit(data):
-    logger.info(data)
     if not koboldai_vars.noai and data['theme']:
         # Random prompt generation
         logger.debug("doing random prompt")

--- a/aiserver.py
+++ b/aiserver.py
@@ -6194,8 +6194,14 @@ def UI_2_submit(data):
         # Invalid enum lookup!
         gen_mode = GenerationMode.STANDARD
         logger.warning(f"Unknown gen_mode '{gen_mode_name}', using STANDARD! Report this!")
+    
+    new_action_text = data['data']
+    if koboldai_vars.instruction != "":
+        new_action_text += "{{[INPUT]}}"
+        new_action_text += koboldai_vars.instruction
+        new_action_text += "{{[OUTPUT]}}"
 
-    actionsubmit(data['data'], actionmode=koboldai_vars.actionmode, gen_mode=gen_mode)
+    actionsubmit(new_action_text, actionmode=koboldai_vars.actionmode, gen_mode=gen_mode)
 
  #==================================================================#
 # Event triggered when user clicks the submit button

--- a/aiserver.py
+++ b/aiserver.py
@@ -6172,6 +6172,7 @@ def UI_2_delete_option(data):
 @socketio.on('submit')
 @logger.catch
 def UI_2_submit(data):
+    logger.info(data)
     if not koboldai_vars.noai and data['theme']:
         # Random prompt generation
         logger.debug("doing random prompt")
@@ -6196,9 +6197,9 @@ def UI_2_submit(data):
         logger.warning(f"Unknown gen_mode '{gen_mode_name}', using STANDARD! Report this!")
     
     new_action_text = data['data']
-    if koboldai_vars.instruction != "":
+    if data['instruction'] != "":
         new_action_text += "{{[INPUT]}}"
-        new_action_text += koboldai_vars.instruction
+        new_action_text += data['instruction']
         new_action_text += "{{[OUTPUT]}}"
 
     actionsubmit(new_action_text, actionmode=koboldai_vars.actionmode, gen_mode=gen_mode)

--- a/aiserver.py
+++ b/aiserver.py
@@ -6197,9 +6197,13 @@ def UI_2_submit(data):
     
     new_action_text = data['data']
     if data['instruction'] != "":
+        new_action_text += chr(29)
         new_action_text += "{{[INPUT]}}"
+        new_action_text += chr(29)
         new_action_text += data['instruction']
+        new_action_text += chr(29)
         new_action_text += "{{[OUTPUT]}}"
+        
 
     actionsubmit(new_action_text, actionmode=koboldai_vars.actionmode, gen_mode=gen_mode)
 

--- a/gensettings.py
+++ b/gensettings.py
@@ -1049,9 +1049,9 @@ gensettingstf = [
 	"step": 1,
 	"default": 0,
     "tooltip": "If set, the instruction will appear in the game text (Visual only)",
-    "menu_path": "Settings",
-    "sub_path": "instruction",
-    "classname": "story",
+    "menu_path": "Interface",
+    "sub_path": "UI",
+    "classname": "user",
     "name": "show_instruction",
     "ui_level": 0
 	},

--- a/gensettings.py
+++ b/gensettings.py
@@ -1021,7 +1021,7 @@ gensettingstf = [
     "name": "wigen_use_own_wi",
     "ui_level": 2
 	},
-       {
+    {
     "UI_V2_Only": True,
 	"uitype": "toggle",
 	"unit": "bool",
@@ -1036,6 +1036,23 @@ gensettingstf = [
     "sub_path": "model",
     "classname": "model",
     "name": "enable_instruction_mode",
+    "ui_level": 0
+	},
+    {
+    "UI_V2_Only": True,
+	"uitype": "toggle",
+	"unit": "bool",
+	"label": "Show Instruction",
+	"id": "show_instruction", 
+	"min": 0,
+	"max": 1,
+	"step": 1,
+	"default": 0,
+    "tooltip": "If set, the instruction will appear in the game text (Visual only)",
+    "menu_path": "Settings",
+    "sub_path": "instruction",
+    "classname": "story",
+    "name": "show_instruction",
     "ui_level": 0
 	},
 ]

--- a/gensettings.py
+++ b/gensettings.py
@@ -1021,6 +1021,23 @@ gensettingstf = [
     "name": "wigen_use_own_wi",
     "ui_level": 2
 	},
+       {
+    "UI_V2_Only": True,
+	"uitype": "toggle",
+	"unit": "bool",
+	"label": "Instruction Mode",
+	"id": "enable_instruction_mode", 
+	"min": 0,
+	"max": 1,
+	"step": 1,
+	"default": 0,
+    "tooltip": "Whether the model should use instruction mode (user gives instrutions to the AI to act on).",
+    "menu_path": "Home",
+    "sub_path": "model",
+    "classname": "model",
+    "name": "enable_instruction_mode",
+    "ui_level": 0
+	},
 ]
 
 gensettingsik =[{
@@ -1335,6 +1352,7 @@ gensettingsik =[{
     "classname": "user",
     "name": "singleline"
  	},
+
 ]
 
 formatcontrols = [{

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -1235,6 +1235,7 @@ class user_settings(settings):
         self.horde_worker_name = "My Awesome Instance"
         self.horde_url = "https://horde.koboldai.net"
         self.model_selected = ""
+        self.show_instruction = True
         
     def __setattr__(self, name, value):
         new_variable = name not in self.__dict__
@@ -2054,6 +2055,7 @@ class KoboldStoryRegister(object):
         ########### Add in the instruction mode header/footer ############
         action_text = action_text.replace("{{[INPUT]}}", self._koboldai_vars.instruction_start)
         action_text = action_text.replace("{{[OUTPUT]}}", self._koboldai_vars.instruction_end)
+        action_text = action_text.replace(chr(29), "")
         
         ###########action_text_split = [sentence, actions used in sentence, token length, included in AI context]################
         action_text_split = [[x, [], 0, False] for x in self.sentence_re.findall(action_text)]

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -317,6 +317,15 @@ class koboldai_vars(object):
             used_tokens += len(genre_tokens)
 
 
+        ######################################### Add Instruction ###################################################
+        if self.enable_instruction_mode:
+            instruction_text = self.instruction_start + self.instruction + self.instruction_end
+            instruction_tokens = self.tokenizer.encode(instruction_text)
+            self.instruction_length = len(instruction_tokens)
+            used_tokens += len(instruction_tokens)
+        
+            
+
         ######################################### Add memory ########################################################
         max_memory_length = int(token_budget * self.max_memory_fraction)
         memory_text = self.memory
@@ -543,6 +552,14 @@ class koboldai_vars(object):
         
         context += game_context
         
+        ######################################### Add Instruction ###################################################
+        if self.enable_instruction_mode:
+            context.append({
+                "type": "instruction",
+                "text": instruction_text,
+                "tokens": [[x, self.tokenizer.decode(x)] for x in instruction_tokens],
+            })
+        
         if len(context) == 0:
             tokens = []
         else:
@@ -759,6 +776,9 @@ class model_settings(settings):
         self.horde_queue_position = 0
         self.horde_queue_size = 0
         self.use_alt_rep_pen = False
+        self.instruction_start = ""
+        self.instruction_end = ""
+        self.enable_instruction_mode = False
         
         
 
@@ -962,6 +982,9 @@ class story_settings(settings):
         self.commentary_enabled = False
         
         self.save_paths = SavePaths(os.path.join("stories", self.story_name or "Untitled"))
+        
+        self.instruction = ""
+        self.instruction_length = 0
 
         ################### must be at bottom #########################
         self.no_save = False  #Temporary disable save (doesn't save with the file)
@@ -1131,6 +1154,8 @@ class story_settings(settings):
             elif name == 'authornotetemplate':
                 ignore = self._koboldai_vars.calc_ai_text()
             elif name == 'memory':
+                ignore = self._koboldai_vars.calc_ai_text()
+            elif name == 'instruction':
                 ignore = self._koboldai_vars.calc_ai_text()
             elif name == "genres":
                 self._koboldai_vars.calc_ai_text()

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -985,6 +985,8 @@ class story_settings(settings):
         
         self.instruction = ""
         self.instruction_length = 0
+        
+        self.show_instruction = False
 
         ################### must be at bottom #########################
         self.no_save = False  #Temporary disable save (doesn't save with the file)

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -2461,6 +2461,7 @@ body {
 
 .context-sp {background-color: var(--context_colors_soft_prompt);}
 .context-genre {background-color: var(--context_colors_genre);}
+.context-instruction {background-color: var(--context_colors_instruction);}
 .context-prompt {background-color: var(--context_colors_prompt);}
 .context-wi {background-color: var(--context_colors_world_info);}
 .context-memory {background-color: var(--context_colors_memory);}

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -1787,6 +1787,12 @@ body {
 	grid-area: textarea;
 }
 
+#instruction_text{
+	display: flex;
+	flex-direction: column;
+	grid-area: textarea;
+}
+
 #themetext{
 	height: 100%;
 	width: 100%;

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -1791,6 +1791,8 @@ body {
 	display: flex;
 	flex-direction: column;
 	grid-area: textarea;
+	width: 50%;
+	margin-left: 50%;
 }
 
 #themetext{

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -96,6 +96,7 @@ var privacy_mode_enabled = false;
 var attention_wanting_wi_bar = null;
 var ai_busy = false;
 var can_show_options = true;
+var show_instructions = false;
 
 var streaming = {
 	windowOpen: false,
@@ -763,7 +764,11 @@ function do_story_text_updates(action) {
 			for (chunk of action.action['wi_highlighted_text']) {
 				chunk_element = document.createElement("span");
 				//Do instruction removal here if enabled
-				chunk_element.innerText = chunk['text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
+				if (!document.getElementById('user_show_instruction').checked) {
+					chunk_element.innerText = chunk['text'].split(String.fromCharCode(29))[0];
+				} else {
+					chunk_element.innerText = chunk['text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
+				}
 				if (chunk['WI matches'] != null) {
 					chunk_element.classList.add("wi_match");
 					chunk_element.setAttribute("tooltip", chunk['WI Text']);
@@ -774,7 +779,11 @@ function do_story_text_updates(action) {
 		} else {
 			chunk_element = document.createElement("span");
 			//Do instruction removal here if enabled
-			chunk_element.innerText = action.action['Selected Text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
+			if (!document.getElementById('user_show_instruction').checked) {
+				chunk_element.innerText = action.action['Selected Text'].split(String.fromCharCode(29))[0];
+			} else {
+				chunk_element.innerText = action.action['Selected Text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
+			}
 			item.append(chunk_element);
 		}
 		item.original_text = action.action['Selected Text'];
@@ -3426,6 +3435,15 @@ function gametextwatcher(records) {
 		//get the actual chunk rather than the sub-node
 		//console.log(record);
 		var chunk = record.target;
+		var original_text;
+		if (chunk.getAttribute("chunk") != null) {
+			if (document.getElementById('user_show_instruction').checked) {
+				original_text = actions_data[chunk.getAttribute("chunk")]["Selected Text"].replace("{{[INPUT]}}", document.getElementById('instruction_start').value).replace("{{[OUTPUT]}}", document.getElementById('instruction_end').value)
+			} else {
+				original_text = actions_data[chunk.getAttribute("chunk")]["Selected Text"].split(String.fromCharCode(29))[0];
+			}
+			console.log(original_text);
+		}
 		var found_chunk = false;
 		while (chunk != game_text) {
 			if (chunk) {
@@ -3438,7 +3456,7 @@ function gametextwatcher(records) {
 				break;
 			}
 		}
-		if ((found_chunk) && (chunk.original_text != chunk.innerText)) {;
+		if ((found_chunk) && (original_text != chunk.innerText)) {;
 			if (!dirty_chunks.includes(chunk.getAttribute("chunk"))) {
 				dirty_chunks.push(chunk.getAttribute("chunk"));
 			}
@@ -3534,7 +3552,6 @@ function savegametextchanges() {
 	}
 	dirty_chunks = [];
 }
-
 
 function update_game_text(id, new_text) {
 	let temp = null;

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -375,7 +375,8 @@ function reset_story() {
 	if (storyPrompt) {
 		storyPrompt.setAttribute("world_info_uids", "");
 	}
-	document.getElementById('themerow').classList.remove("hidden");
+	//document.getElementById('themerow').classList.remove("hidden");
+	document.getElementById('prompt_menu_random').classList.remove("hidden");
 	document.getElementById('input_text').placeholder = "Enter Prompt Here (shift+enter for new line)";
 	text = "";
 	for (i=0;i<70;i++) {
@@ -823,7 +824,8 @@ function do_prompt(data) {
 	//if we have a prompt we need to disable the theme area, or enable it if we don't
 	if (data.value[0].text != "") {
 		document.getElementById('input_text').placeholder = "Enter text here (shift+enter for new line)";
-		document.getElementById('themerow').classList.add("hidden");
+		//document.getElementById('themerow').classList.add("hidden");
+		document.getElementById('prompt_menu_random').classList.add("hidden");
 		document.getElementById('themetext').value = "";
 		document.getElementById("welcome_container").classList.add("hidden");
 		//enable editing
@@ -831,7 +833,8 @@ function do_prompt(data) {
 	} else {
 		document.getElementById('input_text').placeholder = "Enter Prompt Here (shift+enter for new line)";
 		document.getElementById('input_text').disabled = false;
-		document.getElementById('themerow').classList.remove("hidden");
+		//document.getElementById('themerow').classList.remove("hidden");
+		document.getElementById('prompt_menu_random').classList.remove("hidden");
 		addInitChatMessage();
 	}
 	
@@ -3630,6 +3633,28 @@ function save_preset() {
 }
 
 //--------------------------------------------General UI Functions------------------------------------
+function set_input_type(input) {
+	for (item of document.getElementsByClassName("prompt_menu")) {
+		if (input != item) {
+			item.classList.remove("selected");
+			if (document.getElementById(item.getAttribute("textarea_name"))) {
+				document.getElementById(item.getAttribute("textarea_name")).classList.add("hidden");
+			}
+		} else {
+			item.classList.add("selected");
+			if (document.getElementById(item.getAttribute("textarea_name"))) {
+				document.getElementById(item.getAttribute("textarea_name")).classList.remove("hidden");
+			}
+		}
+	}
+	//we want to disable the submit button when on the instruction input as that is just a normal sync, not a submit thing
+	if (input.id == 'prompt_menu_instruction') {
+		document.getElementById('btnsubmit').disabled = true;
+	} else {
+		document.getElementById('btnsubmit').disabled = false;
+	}
+}
+
 function put_cursor_at_element(element) {
 	var range = document.createRange();
 	var sel = window.getSelection();

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -3953,7 +3953,8 @@ function calc_token_usage(
 	prompt_length,
 	game_text_length,
 	world_info_length,
-	submit_length
+	submit_length,
+	instruction_length
 ) {
 	let total_tokens = parseInt(document.getElementById('model_max_length_cur').value);
 	let unused_token_count = total_tokens - memory_length - authors_note_length - world_info_length - prompt_length - game_text_length - submit_length;
@@ -3961,6 +3962,7 @@ function calc_token_usage(
 	const data = [
 		{id: "soft_prompt_tokens", tokenCount: soft_prompt_length, label: "Soft Prompt"},
 		{id: "genre_tokens", tokenCount: genre_length, label: "Genre"},
+		{id: "instruction_tokens", tokenCount: instruction_length, label: "Instruction"},
 		{id: "memory_tokens", tokenCount: memory_length, label: "Memory"},
 		{id: "authors_notes_tokens", tokenCount: authors_note_length, label: "Author's Note"},
 		{id: "world_info_tokens", tokenCount: world_info_length, label: "World Info"},
@@ -4398,6 +4400,7 @@ function update_context(data) {
 	let world_info_length = 0;
 	let soft_prompt_length = 0;
 	let submit_length = 0;
+	let instruction_length = 0;
 	
 	//clear out within_max_length class
 	for (action of document.getElementsByClassName("within_max_length")) {
@@ -4417,7 +4420,8 @@ function update_context(data) {
 			memory: "memory",
 			authors_note: "an",
 			action: "action",
-			submit: 'submit'
+			submit: 'submit',
+			instruction: 'instruction'
 		}[entry.type]);
 
 		let el = $e(
@@ -4446,6 +4450,9 @@ function update_context(data) {
 		switch (entry.type) {
 			case 'soft_prompt':
 				soft_prompt_length += entry.tokens.length;
+				break;
+			case 'instruction':
+				instruction_length += entry.tokens.length;
 				break;
 			case 'prompt':
 				const promptEl = document.getElementById('story_prompt');
@@ -4493,7 +4500,8 @@ function update_context(data) {
 		prompt_length,
 		game_text_length,
 		world_info_length,
-		submit_length
+		submit_length,
+		instruction_length
 	);
 
 

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -693,6 +693,8 @@ function parseChatMessages(text) {
 function do_story_text_updates(action) {
 	story_area = document.getElementById('Selected Text');
 	current_chunk_number = action.id;
+	let instruction_start = document.getElementById('instruction_start');
+	let instruction_end = document.getElementById('instruction_end');
 	let item = null;
 
 	if (chat.useV2) {
@@ -755,7 +757,8 @@ function do_story_text_updates(action) {
 		if ('wi_highlighted_text' in action.action) {
 			for (chunk of action.action['wi_highlighted_text']) {
 				chunk_element = document.createElement("span");
-				chunk_element.innerText = chunk['text'];
+				//Do instruction removal here if enabled
+				chunk_element.innerText = chunk['text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
 				if (chunk['WI matches'] != null) {
 					chunk_element.classList.add("wi_match");
 					chunk_element.setAttribute("tooltip", chunk['WI Text']);
@@ -765,7 +768,8 @@ function do_story_text_updates(action) {
 			}
 		} else {
 			chunk_element = document.createElement("span");
-			chunk_element.innerText = action.action['Selected Text'];
+			//Do instruction removal here if enabled
+			chunk_element.innerText = action.action['Selected Text'].replace('{{[INPUT]}}', instruction_start.value).replace('{{[OUTPUT]}}', instruction_end.value);
 			item.append(chunk_element);
 		}
 		item.original_text = action.action['Selected Text'];
@@ -3633,6 +3637,22 @@ function save_preset() {
 }
 
 //--------------------------------------------General UI Functions------------------------------------
+
+const instruction_expand_size = 90; //size the instruction area should resize to as a percent (less than 100)
+function resize_instruction(input) {
+	input = this;
+	console.log(input);
+	if (input.id == 'input_text') {
+		document.getElementById('input_text').style.width = instruction_expand_size.toString() + '%';
+		document.getElementById('instruction_text').style.width = (100-instruction_expand_size).toString() + '%';
+		document.getElementById('instruction_text').style.marginLeft = instruction_expand_size.toString() + '%';
+	} else {
+		document.getElementById('input_text').style.width = (100-instruction_expand_size).toString() + '%';
+		document.getElementById('instruction_text').style.width = instruction_expand_size.toString() + '%';
+		document.getElementById('instruction_text').style.marginLeft = (100-instruction_expand_size).toString() + '%';
+	}
+}
+
 function set_input_type(input) {
 	for (item of document.getElementsByClassName("prompt_menu")) {
 		if (input != item) {
@@ -3647,12 +3667,19 @@ function set_input_type(input) {
 			}
 		}
 	}
-	//we want to disable the submit button when on the instruction input as that is just a normal sync, not a submit thing
-	if (input.id == 'prompt_menu_instruction') {
-		document.getElementById('btnsubmit').disabled = true;
+	
+	if (input.getAttribute("textarea_name") == 'instruction_text') {
+		//We want to enable the normal submit with additional JS for on click so it expands the area
+		document.getElementById('input_text').classList.remove("hidden")
+		document.getElementById('input_text').style.width = "50%";
+		document.getElementById('instruction_text').style.width = "50%";
+		document.getElementById('instruction_text').style.marginLeft = '50%';
+		document.getElementById('input_text').addEventListener('click', resize_instruction);
 	} else {
-		document.getElementById('btnsubmit').disabled = false;
+		document.getElementById('input_text').removeEventListener("click", resize_instruction);
+		document.getElementById('input_text').style.width = "100%";
 	}
+	
 }
 
 function put_cursor_at_element(element) {

--- a/static/koboldai.js
+++ b/static/koboldai.js
@@ -296,10 +296,15 @@ function storySubmit(genMode=null) {
 	const textInput = document.getElementById("input_text");
 	const themeInput = document.getElementById("themetext");
 	disruptStoryState();
+	let instruction = "";
+	if (!(document.getElementById('instruction_text').classList.contains('hidden'))) {
+		instruction = document.getElementById('instruction_text').value;
+	}
 	socket.emit('submit', {
 		data: textInput.value,
 		theme: themeInput.value,
 		gen_mode: genMode,
+		'instruction': instruction
 	});
 
 	textInput.value = '';

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -135,6 +135,8 @@
 	<!------------- Pop-Ups ------------------------------->
 	{% include 'popups.html' %}
 	
+	<!------------- hidden inputs ------------------------------->
+	
 	<!------------- Templates ------------------------------->
 	<div class="hidden">
 		{% include 'templates.html' %}

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -71,14 +71,9 @@
 		<!------------ Theme Area--------------------->
 		<div class="themerow" id="themerow">
 			<div class="tabrow nomenu_icon">
-				<span class="prompt_menu selected" id="prompt_menu_random" onclick="this.classList.add('selected');
-															document.getElementById('prompt_menu_normal').classList.remove('selected');
-															document.getElementById('random_game_prompt').classList.add('hidden');
-															document.getElementById('input_text').classList.remove('hidden');">Prompt</span>
-				<span class="prompt_menu" id="prompt_menu_normal" onclick="this.classList.add('selected');
-															document.getElementById('prompt_menu_random').classList.remove('selected');
-															document.getElementById('random_game_prompt').classList.remove('hidden');
-															document.getElementById('input_text').classList.add('hidden');">Random Prompt</span>
+				<span class="prompt_menu selected" id="prompt_menu_normal" textarea_name='input_text' onclick="set_input_type(this);">Prompt</span>
+				<span class="prompt_menu" id="prompt_menu_random" textarea_name='random_game_prompt' onclick="set_input_type(this);">Random Prompt</span>
+				<span class="prompt_menu" id="prompt_menu_instruction" textarea_name='instruction_text' onclick="set_input_type(this);">Instruction</span>
 			</div>
 		</div>
 		<!------------ Input Area--------------------->
@@ -89,10 +84,11 @@
 				<span class="help_text" style="margin:0px;margin-top:5px;">The AI can create a prompt for you! Optionally type in one or more themes above, or let the AI do it's thing.</span>
 			</div>
 			<button class="var_sync_alt_story_storymode action_button" id="adventure_mode" onclick="toggle_adventure_mode(this);"><span style="font-weight: bold;">Mode: </span><span>Story</span></button>
-			<textarea autocomplete="off" row=5 id="input_text" placeholder="Enter Prompt Here (shift+enter for new line)" oninput='if (this.value != "") {
+			<textarea autocomplete="off" rows=5 id="input_text" placeholder="Enter Prompt Here (shift+enter for new line)" oninput='if (this.value != "") {
 																											document.getElementById("themetext").value = "";
 																										}'
 																										onkeyup="update_token_lengths()"></textarea>
+			<textarea autocomplete="off" rows=5 id="instruction_text" placeholder="Enter Instruction Here" class="var_sync_model_instruction hidden" onchange='sync_to_server(this);' ></textarea>
 			<div class="statusbar_outer hidden var_sync_alt_system_aibusy" id="status_bar" onclick="socket.emit('abort','');">
 				<div class="statusbar_inner" style="width:0%" onclick="socket.emit('abort','');">
 					<div id="status_bar_percent">0%</div>

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -88,7 +88,7 @@
 																											document.getElementById("themetext").value = "";
 																										}'
 																										onkeyup="update_token_lengths()"></textarea>
-			<textarea autocomplete="off" rows=5 id="instruction_text" placeholder="Enter Instruction Here" class="var_sync_model_instruction hidden" onchange='sync_to_server(this);' ></textarea>
+			<textarea autocomplete="off" rows=5 id="instruction_text" placeholder="Enter Instruction Here" class="var_sync_model_instruction hidden" onchange='sync_to_server(this);' onclick='resize_instruction(this);'></textarea>
 			<div class="statusbar_outer hidden var_sync_alt_system_aibusy" id="status_bar" onclick="socket.emit('abort','');">
 				<div class="statusbar_inner" style="width:0%" onclick="socket.emit('abort','');">
 					<div id="status_bar_percent">0%</div>

--- a/templates/index_new.html
+++ b/templates/index_new.html
@@ -88,7 +88,7 @@
 																											document.getElementById("themetext").value = "";
 																										}'
 																										onkeyup="update_token_lengths()"></textarea>
-			<textarea autocomplete="off" rows=5 id="instruction_text" placeholder="Enter Instruction Here" class="var_sync_model_instruction hidden" onchange='sync_to_server(this);' onclick='resize_instruction(this);'></textarea>
+			<textarea autocomplete="off" rows=5 id="instruction_text" placeholder="Enter Instruction Here" class="var_sync_story_instruction hidden" onchange='sync_to_server(this);' onclick='resize_instruction(this);'></textarea>
 			<div class="statusbar_outer hidden var_sync_alt_system_aibusy" id="status_bar" onclick="socket.emit('abort','');">
 				<div class="statusbar_inner" style="width:0%" onclick="socket.emit('abort','');">
 					<div id="status_bar_percent">0%</div>

--- a/templates/popups.html
+++ b/templates/popups.html
@@ -194,6 +194,7 @@
 					<div>
 						<span class="noselect context-block-example context-sp">Soft Prompt</span>
 						<span class="noselect context-block-example context-genre">Genre</span>
+						<span class="noselect context-block-example context-instruction">Instruction</span>
 						<span class="noselect context-block-example context-memory">Memory</span>
 						<span class="noselect context-block-example context-wi">World Info</span>
 						<span class="noselect context-block-example context-an">Author's Note</span>

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -54,6 +54,11 @@
 					</div>	
 				</div>
 			{% endif %}
+			{% with menu='Home' %}
+				{% with sub_path='model' %}
+					{% include 'settings item.html' %}
+				{% endwith %}
+			{% endwith %}
 		</div>
 		<div id="Story_Info">
 			<hr/>
@@ -195,6 +200,14 @@
 				{% with sub_path='Repetition' %}
 					{% include 'settings item.html' %}
 				{% endwith %}
+			</div>
+			<div class="collapsable_header" onclick="toggle_setting_category(this);">
+				<h4 style="width:var(--flyout_menu_width);"><span class="material-icons-outlined cursor">expand_more</span> Instruction Mode</h4>
+			</div>
+			<div class="setting_tile_area">
+				<textarea rows=2 id="instruction_start" class="var_sync_model_instruction_start var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Text to send to the AI before the instruction"></textarea><br>
+				User instruction goes here<br>
+				<textarea rows=2 id="instruction_end" class="var_sync_model_instruction_end var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Text to send to the AI after the instruction"></textarea>
 			</div>
 			
 			<div class="collapsable_header" onclick="toggle_setting_category(this);">

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -207,7 +207,10 @@
 			<div class="setting_tile_area">
 				<textarea rows=2 id="instruction_start" class="var_sync_model_instruction_start var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Text to send to the AI before the instruction"></textarea><br>
 				User instruction goes here<br>
-				<textarea rows=2 id="instruction_end" class="var_sync_model_instruction_end var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Text to send to the AI after the instruction"></textarea>
+				<textarea rows=2 id="instruction_end" class="var_sync_model_instruction_end var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Text to send to the AI after the instruction"></textarea><br>
+				{% with sub_path='instruction' %}
+					{% include 'settings item.html' %}
+				{% endwith %}
 			</div>
 			
 			<div class="collapsable_header" onclick="toggle_setting_category(this);">

--- a/templates/story flyout.html
+++ b/templates/story flyout.html
@@ -29,13 +29,13 @@
 				</script>
 			</div>
 		</div>
-		<div id="instruction_mode">
+		<!---<div id="instruction_mode">
 			<h4 class="section_header"><label for="instruction_mode">Instruction Mode</label></h4>
 			<div class="help_text">
 				The instruction the AI should act on
 			</div>
 			<textarea rows=2 id="instruction" class="var_sync_model_instruction var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Instruction the AI will act on"></textarea><br>
-		</div>
+		</div>--->
 		<div id="Auto-Memory" class="var_sync_alt_system_experimental_features">
 			<h4 class="section_header"><label for="auto_memory">Auto-Memory (non-functional)</label></h4>
 			<div class="help_text">

--- a/templates/story flyout.html
+++ b/templates/story flyout.html
@@ -29,6 +29,13 @@
 				</script>
 			</div>
 		</div>
+		<div id="instruction_mode">
+			<h4 class="section_header"><label for="instruction_mode">Instruction Mode</label></h4>
+			<div class="help_text">
+				The instruction the AI should act on
+			</div>
+			<textarea rows=2 id="instruction" class="var_sync_model_instruction var_sync_alt_story_instruction_length fullwidth" onchange='sync_to_server(this);' oninput="autoResize(this)" autocomplete="off" placeholder="Instruction the AI will act on"></textarea><br>
+		</div>
 		<div id="Auto-Memory" class="var_sync_alt_system_experimental_features">
 			<h4 class="section_header"><label for="auto_memory">Auto-Memory (non-functional)</label></h4>
 			<div class="help_text">
@@ -126,6 +133,7 @@
 		<div class="token_breakdown" onclick='socket.emit("update_tokens", document.getElementById("input_text").value);openPopup("context-viewer");'>
 			<div id="soft_prompt_tokens" style="width:0%; background-color: var(--context_colors_soft_prompt);"></div>
 			<div id="genre_tokens" style="width:40%; background-color: var(--context_colors_genre);"></div>
+			<div id="instruction_tokens" style="width:40%; background-color: var(--context_colors_instruction);"></div>
 			<div id="memory_tokens" style="width:40%; background-color: var(--context_colors_memory);"></div>
 			<div id="authors_notes_tokens" style="width:10%; background-color: var(--context_colors_authors_notes);"></div>
 			<div id="world_info_tokens" style="width:20%; background-color: var(--context_colors_world_info);"></div>

--- a/themes/Darkness.css
+++ b/themes/Darkness.css
@@ -223,7 +223,7 @@
 
 /* Boxes */
 
-#input_text, #themetext {
+#input_text, #themetext, #instruction_text {
     border-color: #b6b6b6 !important;
 }
 

--- a/themes/Darkness.css
+++ b/themes/Darkness.css
@@ -169,6 +169,8 @@
 	--context_colors_submit: #ffffff00;
 	--context_colors_unused: #ffffff11;
 	--context_colors_soft_prompt: #141414;
+	--context_colors_genre: #454545;
+	--context_colors_instruction: #6D6D6D;
 	
 
     /*Parameters*/

--- a/themes/Gruvbox Dark.css
+++ b/themes/Gruvbox Dark.css
@@ -235,6 +235,8 @@
 	--context_colors_submit: var(--gruvbox-light4);
 	--context_colors_unused: var(--gruvbox-light0);
 	--context_colors_soft_prompt: var(--gruvbox-neutral-aqua);
+	--context_colors_genre: #873139;
+	--context_colors_instruction: #3D8830;
 }
 
 /* Overrides */

--- a/themes/Gruvbox Dark.css
+++ b/themes/Gruvbox Dark.css
@@ -264,7 +264,7 @@ hr, #token-breakdown-container, .tabrow::before {
 	margin-bottom: 7px;
 }
 
-#input_text, #themetext {
+#input_text, #themetext, #instruction_text {
 	border: none !important;
 }
 

--- a/themes/Material You.css
+++ b/themes/Material You.css
@@ -177,6 +177,7 @@
 	--context_colors_submit: #221f24;
 	--context_colors_unused: white;
 	--context_colors_soft_prompt: #000080;
+	--context_colors_instruction: #B60AEC;
 
     /*Parameters*/
 	--scrollbar-size: 6px;

--- a/themes/Monochrome.css
+++ b/themes/Monochrome.css
@@ -169,6 +169,7 @@
 	--context_colors_unused: #ffffff24;
 	--context_colors_soft_prompt: #141414;
 	--context_colors_genre: #2c5c88;
+	--context_colors_instruction: #4106B6;
 
     /*Parameters*/
 	--scrollbar-size: 6px;

--- a/themes/Monochrome.css
+++ b/themes/Monochrome.css
@@ -231,7 +231,7 @@
 	border-bottom: 1px solid #2f3b4b;
 }
 
-#input_text, #themetext {
+#input_text, #themetext, #instruction_text {
     border-color: #2f3b4b !important;
 }
 

--- a/themes/Nostalgia.css
+++ b/themes/Nostalgia.css
@@ -222,7 +222,7 @@
 
 /* Boxes */
 
-#input_text, #themetext {
+#input_text, #themetext, #instruction_text {
     border-color: #999999 !important;
 }
 

--- a/themes/Nostalgia.css
+++ b/themes/Nostalgia.css
@@ -168,6 +168,8 @@
 	--context_colors_submit: #ffffff00;
 	--context_colors_unused: #ffffff24;
 	--context_colors_soft_prompt: #262626;
+	--context_colors_genre: #3452A6;
+	--context_colors_instruction: #175C0C;
 
     /*Parameters*/
 	--scrollbar-size: 6px;

--- a/themes/Unicorn.css
+++ b/themes/Unicorn.css
@@ -173,6 +173,8 @@
 	--context_colors_submit: #ffffff00;
 	--context_colors_unused: #ffffff5c;
 	--context_colors_soft_prompt: #222224;
+	--context_colors_genre: #797979;
+	--context_colors_instruction: #9B5783;
 
     /*Parameters*/
 	--scrollbar-size: 6px;

--- a/themes/Unicorn.css
+++ b/themes/Unicorn.css
@@ -229,7 +229,7 @@
 
 /* Boxes */
 
-#input_text, #themetext {
+#input_text, #themetext, #instruction_text {
     border-color: #c9c9c9 !important;
 }
 


### PR DESCRIPTION
First version.
Start and End instruction text is in the settings menu under instructions area
Actual instruction is accessed by clicking on the Instruction button under the game text above the prompt box.
I did keep the prompt and instruction separate so that users can enter additional story before giving an instruction. Box expands when clicking in it to make it easier to write.

To Do:
Add instruction templates with a drop-down for easier user experience
