### PR TITLE
Exllama2 GPU Split

### DIFF
--- a/modeling/inference_models/exllamav2/class.py
+++ b/modeling/inference_models/exllamav2/class.py
@@ -54,9 +54,6 @@ class LayerSplitExLlamaV2(ExLlamaV2):
     # sized uniformly, but we shall see!
 
     def set_device_map(self, device_map, embed_cpu = True) -> int:
-        for module in self.modules:
-            print(type(module), module.weight_footprint())
-
         self.cache_map = {}
         device_map = list(device_map)
 
@@ -73,7 +70,6 @@ class LayerSplitExLlamaV2(ExLlamaV2):
                 # The weight of attention heads is like 1/3 of the weight of
                 # hidden layers so we'll just stick it after the last hidden
                 # layer (assuming they are sequential).
-                print("Attention @ ", current_index)
                 module.set_device_idx(current_index)
                 continue
             elif isinstance(module, ExLlamaV2RMSNorm) or isinstance(module, ExLlamaV2Linear):

--- a/modeling/inference_models/exllamav2/class.py
+++ b/modeling/inference_models/exllamav2/class.py
@@ -411,8 +411,8 @@ class model_backend(InferenceModel):
 
     def get_requested_parameters(self, model_name, model_path, menu_path, parameters = {}):
         saved_data = {'max_ctx': 2048, 'compress_emb': 1, 'ntk_alpha': 1}
-        if os.path.exists("settings/{}.exllama.model_backend.settings".format(model_name.replace("/", "_"))) and 'base_url' not in vars(self):
-            with open("settings/{}.exllama.model_backend.settings".format(model_name.replace("/", "_")), "r") as f:
+        if os.path.exists("settings/{}.exllamav2.model_backend.settings".format(model_name.replace("/", "_"))) and 'base_url' not in vars(self):
+            with open("settings/{}.exllamav2.model_backend.settings".format(model_name.replace("/", "_")), "r") as f:
                 temp = json.load(f)
                 for key in temp:
                     saved_data[key] = temp[key]


### PR DESCRIPTION
Implements a wrapper class (`LayerSplitExLlamaV2`) to hjijack `ExLlamaV2`'s `set_device_map` to deal in number of hidden layers instead of doing fancy storage calculations

Tested on 13B_Ouroboros_GPTQ as I don't have many compatible models on hand