### PR TITLE
Added model pause/resume button 

### DIFF
--- a/aiserver.py
+++ b/aiserver.py
@@ -6340,7 +6340,37 @@ def UI_2_load_model(data):
     logger.debug("Loading model with user input of: {}".format(data))
     model_backends[data['plugin']].set_input_parameters(data)
     load_model(data['plugin'])
+    if model.model in ["Read Only", ""]:
+        koboldai_vars.model_status = "unloaded"
+    else:
+        koboldai_vars.model_status = "loaded"
     #load_model(use_gpu=data['use_gpu'], gpu_layers=data['gpu_layers'], disk_layers=data['disk_layers'], online_model=data['online_model'], url=koboldai_vars.colaburl, use_8_bit=data['use_8_bit'])
+
+
+#==================================================================#
+# Event triggered when user pauses a model
+#==================================================================#
+@socketio.on('pause_model')
+@logger.catch
+def UI_2_pause_model(data):
+    logger.info("Pausing model (unloading)")
+    if 'model' in globals():
+        model.unload()
+        koboldai_vars.model_status="unloaded"
+        
+        
+#==================================================================#
+# Event triggered when user un-pauses a model
+#==================================================================#
+@socketio.on('unpause_model')
+@logger.catch
+def UI_2_unpause_model(data):
+    logger.info("Un-pausing model (loading)")
+    if 'model' in globals():
+        model.load()
+        koboldai_vars.model_status="loaded"
+        
+        
 
 #==================================================================#
 # Event triggered when load story is clicked

--- a/koboldai_settings.py
+++ b/koboldai_settings.py
@@ -762,6 +762,7 @@ class model_settings(settings):
         self.horde_queue_position = 0
         self.horde_queue_size = 0
         self.use_alt_rep_pen = False
+        self.model_status = "unloaded"
         
         
 

--- a/modeling/inference_models/exllamav2/class.py
+++ b/modeling/inference_models/exllamav2/class.py
@@ -276,8 +276,8 @@ class model_backend(InferenceModel):
         self.cache = None
         self.generator = None
 
-        self.model_name = ""
-        self.path = None
+        #self.model_name = ""
+        #self.path = None
 
         with torch.no_grad():
             with warnings.catch_warnings():

--- a/static/koboldai.css
+++ b/static/koboldai.css
@@ -4030,3 +4030,28 @@ select {
 #load-model .popup_load_cancel {
 	grid-area: ok;
 }
+
+
+.model_pause_button[model_model_status="unloaded"] {
+	display:none
+}
+
+.model_play_button[model_model_status="loaded"] {
+	display:none
+}
+
+.model_pause_button[model_model="Read Only"] {
+	display:none
+}
+
+.model_play_button[model_model="Read Only"] {
+	display:none
+}
+
+.model_pause_button[model_model=""] {
+	display:none
+}
+
+.model_play_button[model_model=""] {
+	display:none
+}

--- a/templates/settings flyout.html
+++ b/templates/settings flyout.html
@@ -43,6 +43,12 @@
 						<span class="material-icons-outlined cursor" tooltip="Load Model" style="font-size: 1.4em;">folder_open</span>
 						<span class="button_label">Load Model</span>
 					</button>
+					<button class="settings_button model_pause_button var_sync_alt_model_model_status var_sync_alt_model_model" onclick="socket.emit('pause_model', {});">
+						<span class="material-icons-outlined cursor" tooltip="Pause Model" style="font-size: 1.4em;">pause</span>
+					</button>
+					<button class="settings_button model_play_button var_sync_alt_model_model_status var_sync_alt_model_model" onclick="socket.emit('unpause_model', {});">
+						<span class="material-icons-outlined cursor" tooltip="Pause Model" style="font-size: 1.4em;">play_arrow</span>
+					</button>
 				{% endif %}
 				<select class="var_sync_model_selected_preset settings_select presets" onchange='sync_to_server(this)'><option>Preset</option></select>
 			</div>


### PR DESCRIPTION
Play/Pause button next to load model button in flyout. When a model is loaded (excluding Read Only) the user can click the pause button to have the model unloaded, freeing up vram. The icon will change to play. When the play button is clicked the model is loaded with the same settings.